### PR TITLE
OpenAI persistent context from GCS (#26)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
             --image="${{ steps.image.outputs.sha_tag }}" \
             --service-account="${RUNTIME_SA}" \
             --set-secrets="TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-default:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-default:latest,TELEGRAM_QA_USERS=telegram-qa-users:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest" \
-            --set-env-vars="SCHEDULER_SERVICE_ACCOUNT_EMAIL=something-bot-scheduler-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+            --set-env-vars="SCHEDULER_SERVICE_ACCOUNT_EMAIL=something-bot-scheduler-sa@${PROJECT_ID}.iam.gserviceaccount.com,OPENAI_CONTEXT_BUCKET=something-bot-openai-context" \
             --quiet
 
       - name: Print deployed revision URL

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ past_inputs/
 
 # but do track Telegram payload fixtures used by the parser tests
 !tests/fixtures/**/*.json
+
+# OpenAI persistent context (#26): synced from GCS via scripts/context-sync.sh.
+# Never commit the actual .md files — they hold personal context. The
+# example placeholder below is intentionally tracked so a new developer
+# sees the convention.
+local-context/*
+!local-context/README.md.example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,24 @@ For private text messages from QA users that no other handler claimed,
 `OpenAIFallbackHandler` (`features/openai_fallback/`) calls the OpenAI
 chat completions API and replies with the response. The system prompt
 lives in `services/openai_client.py::SYSTEM_PROMPT` and is intentionally
-short and neutral; persistent conversation context is post-MVP (#26).
+short and neutral.
+
+### Persistent context (#26)
+
+A dedicated GCS bucket (`OPENAI_CONTEXT_BUCKET`, default
+`something-bot-openai-context`) holds a small set of `.md` files
+prepended to every completion. `services/openai_context.py::OpenAIContextLoader`
+lists objects under `context/`, downloads each, and emits them as
+extra `{"role": "system"}` messages **after** `SYSTEM_PROMPT` but
+**before** the user prompt. Results are cached in-process for 60s so
+we don't hit GCS once per request, and the total payload is capped at
+32 KiB (excess is truncated and logged).
+
+A GCS failure yields an empty context — the completion still runs.
+Markdown is synced from the developer's machine via
+`scripts/context-sync.sh` (`push`/`pull`) — the files themselves are
+gitignored. Bucket versioning is enabled, so an accidental local-side
+deletion can be recovered with `pull` of a prior version.
 
 Defaults: `gpt-4o-mini`, 25s timeout (the Cloud Run request timeout is
 60s, leaving headroom for the orchestrator's persistence work).

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -67,6 +67,25 @@ resource "google_storage_bucket" "telegram_files" {
 }
 
 # --------------------------------------------------------------------------- #
+# GCS bucket for the persistent OpenAI context (#26)
+# --------------------------------------------------------------------------- #
+
+resource "google_storage_bucket" "openai_context" {
+  project                     = var.project_id
+  name                        = var.openai_context_bucket_name
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+
+  versioning {
+    enabled = true
+  }
+
+  depends_on = [google_project_service.enabled]
+}
+
+# --------------------------------------------------------------------------- #
 # Service accounts
 # --------------------------------------------------------------------------- #
 
@@ -247,6 +266,12 @@ resource "google_secret_manager_secret_iam_member" "deployer_webhook_secret" {
 resource "google_storage_bucket_iam_member" "cloudrun_files" {
   bucket = google_storage_bucket.telegram_files.name
   role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+resource "google_storage_bucket_iam_member" "cloudrun_openai_context" {
+  bucket = google_storage_bucket.openai_context.name
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -28,6 +28,11 @@ output "telegram_files_bucket" {
   value       = google_storage_bucket.telegram_files.name
 }
 
+output "openai_context_bucket" {
+  description = "GCS bucket holding the persistent OpenAI context .md files (#26). scripts/context-sync.sh syncs to/from this name."
+  value       = google_storage_bucket.openai_context.name
+}
+
 output "webhook_secret_names" {
   description = "Per-bot Secret Manager secret names holding the Telegram webhook header secret. Values must be populated out-of-band before first deploy."
   value       = { for k, s in google_secret_manager_secret.telegram_webhook_secret : k => s.secret_id }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -38,6 +38,12 @@ variable "telegram_files_bucket_name" {
   default     = "something-bot-telegram-files"
 }
 
+variable "openai_context_bucket_name" {
+  description = "GCS bucket holding the persistent .md context files prepended to OpenAI completions (#26). Synced from the developer's machine via scripts/context-sync.sh."
+  type        = string
+  default     = "something-bot-openai-context"
+}
+
 variable "cloudrun_settings" {
   description = "Cloud Run runtime knobs. Defaults encode the Cloud Run Settings RFC for SPEC §18.3."
   type = object({

--- a/local-context/README.md.example
+++ b/local-context/README.md.example
@@ -1,0 +1,39 @@
+# OpenAI persistent context
+
+This directory holds the markdown files that are prepended to every
+OpenAI chat completion the bot makes (#26). They are **never
+committed** — the directory contents are gitignored except for this
+example.
+
+## Flow
+
+```
+local-context/*.md  ──(scripts/context-sync.sh push)──►  gs://something-bot-openai-context/context/
+                                                              │
+                                                              ▼
+                                                  Cloud Run on each /webhook
+                                                  prepends each file as a
+                                                  {"role": "system"} message
+```
+
+## Conventions
+
+- One topic per file. Suggested starters:
+  - `personal_facts.md` — facts about the user(s) the bot should know.
+  - `project_state.md` — current state of ongoing work.
+  - `terminology.md` — terms / acronyms / aliases the bot should resolve.
+- Keep it under 32 KiB total — the loader truncates beyond that and
+  logs a warning.
+- Pull before editing on a new machine, push after each change:
+
+  ```sh
+  scripts/context-sync.sh pull
+  $EDITOR local-context/personal_facts.md
+  scripts/context-sync.sh push
+  ```
+
+## Why .gitignored
+
+Personal context, not appropriate for a public-ish repo history. Loss
+of a file in this directory is non-fatal — versioning is enabled on
+the bucket, so a `pull` will recover prior versions.

--- a/scripts/.openai-context-bucket
+++ b/scripts/.openai-context-bucket
@@ -1,0 +1,1 @@
+something-bot-openai-context

--- a/scripts/context-sync.sh
+++ b/scripts/context-sync.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Sync the persistent OpenAI context (#26) between this developer's
+# machine and the GCS bucket the Cloud Run runtime reads from.
+#
+# Usage:
+#   scripts/context-sync.sh push   # local-context/  →  gs://<bucket>/context/
+#   scripts/context-sync.sh pull   # gs://<bucket>/context/ → local-context/
+#
+# Bucket name is read from the OPENAI_CONTEXT_BUCKET env var, falling
+# back to the value pinned in scripts/.openai-context-bucket. The
+# bucket name itself is intentionally repo-tracked; only the .md
+# content is gitignored.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_DIR="${REPO_ROOT}/local-context"
+BUCKET_FILE="${REPO_ROOT}/scripts/.openai-context-bucket"
+
+resolve_bucket() {
+    if [[ -n "${OPENAI_CONTEXT_BUCKET:-}" ]]; then
+        echo "${OPENAI_CONTEXT_BUCKET}"
+        return
+    fi
+    if [[ -f "${BUCKET_FILE}" ]]; then
+        head -n 1 "${BUCKET_FILE}"
+        return
+    fi
+    echo "ERROR: bucket name not set (export OPENAI_CONTEXT_BUCKET or populate ${BUCKET_FILE})." >&2
+    exit 2
+}
+
+direction="${1:-}"
+bucket="$(resolve_bucket)"
+remote="gs://${bucket}/context/"
+
+mkdir -p "${LOCAL_DIR}"
+
+case "${direction}" in
+    push)
+        echo "Pushing ${LOCAL_DIR}/  →  ${remote}"
+        gcloud storage rsync "${LOCAL_DIR}/" "${remote}" --delete-unmatched-destination-objects
+        ;;
+    pull)
+        echo "Pulling ${remote}  →  ${LOCAL_DIR}/"
+        gcloud storage rsync "${remote}" "${LOCAL_DIR}/" --delete-unmatched-destination-objects
+        ;;
+    *)
+        echo "Usage: $0 {push|pull}" >&2
+        exit 2
+        ;;
+esac

--- a/src/something_really_bot/config.py
+++ b/src/something_really_bot/config.py
@@ -77,6 +77,15 @@ class Settings(BaseSettings):
         default="gpt-4o-mini",
         description="OpenAI chat model used by the fallback handler.",
     )
+    openai_context_bucket: str | None = Field(
+        default="something-bot-openai-context",
+        description=(
+            "GCS bucket holding the persistent .md context files prepended to "
+            "every OpenAI chat completion (#26). When unset/empty, no context "
+            "is loaded and the fallback handler keeps the #23 no-context "
+            "behaviour."
+        ),
+    )
 
     # --- Feature flags ---
     hello_world_mode: bool = Field(

--- a/src/something_really_bot/services/openai_client.py
+++ b/src/something_really_bot/services/openai_client.py
@@ -1,12 +1,15 @@
-"""Async OpenAI client wrapper used by the fallback handler (#23).
+"""Async OpenAI client wrapper used by the fallback handler (#23, #26).
 
 Wraps :class:`openai.AsyncOpenAI` so handlers depend on a small surface
 (``complete(prompt) -> str``) rather than the SDK directly. Keeping it
 isolated lets us swap to a different LLM provider, add caching, or
 inject test doubles without touching feature code.
 
-The system prompt is intentionally minimal and *neutral*: this is a
-no-context MVP (#23). Persistent shared context lands in #26.
+The system prompt is intentionally minimal and *neutral*. Persistent
+shared context (#26) is loaded by an injected
+:class:`OpenAIContextLoader` and prepended after ``SYSTEM_PROMPT`` but
+before the user's prompt. A GCS failure yields no context — the
+completion still runs.
 """
 
 import asyncio
@@ -17,6 +20,10 @@ from pydantic import SecretStr
 
 from something_really_bot.config import get_settings
 from something_really_bot.logging import get_logger
+from something_really_bot.services.openai_context import (
+    OpenAIContextLoader,
+    get_openai_context_loader,
+)
 
 _logger = get_logger(__name__)
 
@@ -44,10 +51,12 @@ class OpenAIClient:
         model: str,
         client: AsyncOpenAI | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        context_loader: OpenAIContextLoader | None = None,
     ) -> None:
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._client = client or AsyncOpenAI(api_key=api_key.get_secret_value())
+        self._context_loader = context_loader
 
     async def complete(self, prompt: str) -> str:
         """Call chat completions with ``SYSTEM_PROMPT`` + ``prompt``.
@@ -55,14 +64,16 @@ class OpenAIClient:
         Raises:
             OpenAIRequestError: any failure (network, parse, timeout).
         """
+        messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+        if self._context_loader is not None:
+            for chunk in await self._context_loader.get_context_messages():
+                messages.append({"role": "system", "content": chunk})
+        messages.append({"role": "user", "content": prompt})
         try:
             response = await asyncio.wait_for(
                 self._client.chat.completions.create(
                     model=self._model,
-                    messages=[
-                        {"role": "system", "content": SYSTEM_PROMPT},
-                        {"role": "user", "content": prompt},
-                    ],
+                    messages=messages,
                 ),
                 timeout=self._timeout_seconds,
             )
@@ -96,4 +107,8 @@ def get_openai_client() -> OpenAIClient | None:
     settings = get_settings()
     if settings.openai_api_key is None:
         return None
-    return OpenAIClient(api_key=settings.openai_api_key, model=settings.openai_model)
+    return OpenAIClient(
+        api_key=settings.openai_api_key,
+        model=settings.openai_model,
+        context_loader=get_openai_context_loader(),
+    )

--- a/src/something_really_bot/services/openai_context.py
+++ b/src/something_really_bot/services/openai_context.py
@@ -104,9 +104,7 @@ class OpenAIContextLoader:
         return _assemble(blobs, self._max_bytes, self._bucket_name)
 
 
-def _assemble(
-    blobs: Iterable[object], max_bytes: int, bucket_name: str
-) -> tuple[str, ...]:
+def _assemble(blobs: Iterable[object], max_bytes: int, bucket_name: str) -> tuple[str, ...]:
     out: list[str] = []
     remaining = max_bytes
     truncated = False

--- a/src/something_really_bot/services/openai_context.py
+++ b/src/something_really_bot/services/openai_context.py
@@ -1,0 +1,161 @@
+"""GCS-backed context loader for the OpenAI fallback handler (#26).
+
+A small set of ``.md`` files in a dedicated GCS bucket is fetched on
+each call, concatenated into ``{"role": "system", ...}`` messages, and
+prepended after the canonical ``SYSTEM_PROMPT`` but before the user's
+prompt. Sync to/from the bucket happens via ``scripts/context-sync.sh``
+— the markdown is never committed.
+
+Lookups are cached with a small TTL so we're not hitting GCS once per
+request. A GCS failure is logged and yields an empty context — the
+caller still gets a useful reply, just without the context layer.
+
+Token budget: the combined context is capped at
+:data:`MAX_CONTEXT_BYTES`. If it would exceed the cap, files are
+truncated in iteration order until the cap is met. The truncated state
+is logged so it's visible in Cloud Logging.
+"""
+
+import asyncio
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from functools import lru_cache
+
+from something_really_bot.config import get_settings
+from something_really_bot.logging import get_logger
+
+_logger = get_logger(__name__)
+
+DEFAULT_TTL_SECONDS = 60.0
+MAX_CONTEXT_BYTES = 32 * 1024  # 32 KiB — issue #26 documented budget
+OBJECT_PREFIX = "context/"
+
+
+@dataclass(frozen=True)
+class _CachedContext:
+    expires_at: float
+    messages: tuple[str, ...]
+
+
+class OpenAIContextLoader:
+    """Async loader for shared OpenAI context files in GCS."""
+
+    def __init__(
+        self,
+        bucket_name: str,
+        *,
+        prefix: str = OBJECT_PREFIX,
+        client: object | None = None,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        max_bytes: int = MAX_CONTEXT_BYTES,
+        clock: object | None = None,
+    ) -> None:
+        self._bucket_name = bucket_name
+        self._prefix = prefix
+        self._client = client
+        self._ttl_seconds = ttl_seconds
+        self._max_bytes = max_bytes
+        self._clock = clock or time.monotonic
+        self._cached: _CachedContext | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_context_messages(self) -> tuple[str, ...]:
+        """Return the cached context strings, refreshing if stale."""
+        now = self._now()
+        cached = self._cached
+        if cached is not None and cached.expires_at > now:
+            return cached.messages
+
+        async with self._lock:
+            # Re-check after acquiring the lock — another waiter may have refreshed.
+            now = self._now()
+            cached = self._cached
+            if cached is not None and cached.expires_at > now:
+                return cached.messages
+
+            try:
+                messages = await asyncio.to_thread(self._fetch_sync)
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning(
+                    "openai_context_fetch_failed",
+                    extra={
+                        "bucket": self._bucket_name,
+                        "exception_type": type(exc).__name__,
+                    },
+                )
+                messages = ()
+
+            self._cached = _CachedContext(
+                expires_at=self._now() + self._ttl_seconds,
+                messages=messages,
+            )
+            return messages
+
+    def _now(self) -> float:
+        clock = self._clock
+        return clock() if callable(clock) else 0.0
+
+    def _fetch_sync(self) -> tuple[str, ...]:
+        client = self._client or _build_default_client()
+        blobs = list(client.list_blobs(self._bucket_name, prefix=self._prefix))
+        # Sort by name so prepended order is stable.
+        blobs.sort(key=lambda b: getattr(b, "name", ""))
+        return _assemble(blobs, self._max_bytes, self._bucket_name)
+
+
+def _assemble(
+    blobs: Iterable[object], max_bytes: int, bucket_name: str
+) -> tuple[str, ...]:
+    out: list[str] = []
+    remaining = max_bytes
+    truncated = False
+    for blob in blobs:
+        name = getattr(blob, "name", "")
+        if not name.endswith(".md"):
+            continue
+        try:
+            raw = blob.download_as_bytes()
+        except Exception as exc:  # noqa: BLE001 — one bad blob shouldn't kill the rest
+            _logger.warning(
+                "openai_context_blob_download_failed",
+                extra={
+                    "bucket": bucket_name,
+                    "object_key": name,
+                    "exception_type": type(exc).__name__,
+                },
+            )
+            continue
+        if remaining <= 0:
+            truncated = True
+            break
+        if len(raw) > remaining:
+            raw = raw[:remaining]
+            truncated = True
+        remaining -= len(raw)
+        text = raw.decode("utf-8", errors="replace").strip()
+        if text:
+            out.append(text)
+    if truncated:
+        _logger.warning(
+            "openai_context_truncated_to_budget",
+            extra={"bucket": bucket_name, "max_bytes": max_bytes},
+        )
+    return tuple(out)
+
+
+def _build_default_client() -> object:
+    # Deferred import keeps test doubles independent of the GCS SDK.
+    from google.cloud import storage
+
+    return storage.Client()
+
+
+@lru_cache(maxsize=1)
+def get_openai_context_loader() -> OpenAIContextLoader | None:
+    """Return the process-wide loader, or ``None`` if no bucket is configured."""
+    settings = get_settings()
+    bucket = settings.openai_context_bucket
+    if not bucket:
+        return None
+    return OpenAIContextLoader(bucket_name=bucket)

--- a/tests/unit/services/test_openai_client.py
+++ b/tests/unit/services/test_openai_client.py
@@ -66,3 +66,33 @@ async def test_complete_raises_on_empty_content() -> None:
 
     with pytest.raises(OpenAIRequestError):
         await client.complete("hi")
+
+
+class _StaticContextLoader:
+    def __init__(self, messages: tuple[str, ...]) -> None:
+        self._messages = messages
+
+    async def get_context_messages(self) -> tuple[str, ...]:
+        return self._messages
+
+
+async def test_complete_prepends_context_messages_between_system_and_user() -> None:
+    create = AsyncMock(return_value=_fake_response("ok"))
+    fake_chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+    fake_sdk = SimpleNamespace(chat=fake_chat)
+    loader = _StaticContextLoader(("fact: name is Eve", "project: stx-onboarding"))
+    client = OpenAIClient(
+        api_key=SecretStr("test-key"),
+        model="gpt-4o-mini",
+        client=fake_sdk,  # type: ignore[arg-type]
+        timeout_seconds=5.0,
+        context_loader=loader,  # type: ignore[arg-type]
+    )
+
+    await client.complete("what's my name?")
+
+    messages = create.await_args.kwargs["messages"]
+    assert messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
+    assert messages[1] == {"role": "system", "content": "fact: name is Eve"}
+    assert messages[2] == {"role": "system", "content": "project: stx-onboarding"}
+    assert messages[-1] == {"role": "user", "content": "what's my name?"}

--- a/tests/unit/services/test_openai_context.py
+++ b/tests/unit/services/test_openai_context.py
@@ -55,9 +55,7 @@ async def test_get_context_messages_returns_blobs_in_name_order() -> None:
             _FakeBlob(name="context/notes.txt", content=b"ignored"),
         ]
     )
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=client, clock=_ManualClock()
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=client, clock=_ManualClock())
 
     result = await loader.get_context_messages()
 
@@ -68,9 +66,7 @@ async def test_get_context_messages_caches_within_ttl_and_refreshes_after() -> N
     blobs = [_FakeBlob(name="context/a.md", content=b"hello")]
     client = _FakeStorageClient(blobs=blobs)
     clock = _ManualClock()
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=client, ttl_seconds=10.0, clock=clock
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=client, ttl_seconds=10.0, clock=clock)
 
     await loader.get_context_messages()
     await loader.get_context_messages()
@@ -86,9 +82,7 @@ async def test_get_context_messages_returns_empty_when_list_raises() -> None:
         def list_blobs(self, *_a, **_k):
             raise RuntimeError("gcs down")
 
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=_BoomClient(), clock=_ManualClock()
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=_BoomClient(), clock=_ManualClock())
 
     assert await loader.get_context_messages() == ()
 
@@ -101,9 +95,7 @@ async def test_get_context_messages_skips_blob_that_fails_to_download() -> None:
             _FakeBlob(name="context/c.md", content=b"alsogood"),
         ]
     )
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=client, clock=_ManualClock()
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=client, clock=_ManualClock())
 
     result = await loader.get_context_messages()
 
@@ -113,9 +105,7 @@ async def test_get_context_messages_skips_blob_that_fails_to_download() -> None:
 async def test_get_context_messages_truncates_above_byte_budget() -> None:
     big = b"x" * (MAX_CONTEXT_BYTES + 100)
     client = _FakeStorageClient(blobs=[_FakeBlob(name="context/a.md", content=big)])
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=client, clock=_ManualClock()
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=client, clock=_ManualClock())
 
     result = await loader.get_context_messages()
 
@@ -130,8 +120,6 @@ async def test_get_context_messages_ignores_non_markdown_blobs() -> None:
             _FakeBlob(name="context/notes.txt", content=b"drop"),
         ]
     )
-    loader = OpenAIContextLoader(
-        bucket_name="x", client=client, clock=_ManualClock()
-    )
+    loader = OpenAIContextLoader(bucket_name="x", client=client, clock=_ManualClock())
 
     assert await loader.get_context_messages() == ("keep",)

--- a/tests/unit/services/test_openai_context.py
+++ b/tests/unit/services/test_openai_context.py
@@ -1,0 +1,137 @@
+"""Tests for :mod:`something_really_bot.services.openai_context`."""
+
+from dataclasses import dataclass
+
+from something_really_bot.services.openai_context import (
+    MAX_CONTEXT_BYTES,
+    OpenAIContextLoader,
+)
+
+
+@dataclass
+class _FakeBlob:
+    name: str
+    content: bytes = b""
+    raises: BaseException | None = None
+    downloads: int = 0
+
+    def download_as_bytes(self) -> bytes:
+        self.downloads += 1
+        if self.raises is not None:
+            raise self.raises
+        return self.content
+
+
+class _FakeStorageClient:
+    """Returns the same fixed list of blobs to every ``list_blobs`` call.
+
+    Tracks call count so we can assert caching behaviour.
+    """
+
+    def __init__(self, blobs: list[_FakeBlob]) -> None:
+        self._blobs = blobs
+        self.calls: int = 0
+
+    def list_blobs(self, _bucket: str, *, prefix: str = "") -> list[_FakeBlob]:
+        self.calls += 1
+        return [b for b in self._blobs if b.name.startswith(prefix)]
+
+
+class _ManualClock:
+    """A monotonic-clock substitute we can advance from tests."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+async def test_get_context_messages_returns_blobs_in_name_order() -> None:
+    client = _FakeStorageClient(
+        blobs=[
+            _FakeBlob(name="context/b.md", content=b"second"),
+            _FakeBlob(name="context/a.md", content=b"first"),
+            _FakeBlob(name="context/notes.txt", content=b"ignored"),
+        ]
+    )
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=client, clock=_ManualClock()
+    )
+
+    result = await loader.get_context_messages()
+
+    assert result == ("first", "second")
+
+
+async def test_get_context_messages_caches_within_ttl_and_refreshes_after() -> None:
+    blobs = [_FakeBlob(name="context/a.md", content=b"hello")]
+    client = _FakeStorageClient(blobs=blobs)
+    clock = _ManualClock()
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=client, ttl_seconds=10.0, clock=clock
+    )
+
+    await loader.get_context_messages()
+    await loader.get_context_messages()
+    assert client.calls == 1  # cached
+
+    clock.now += 11
+    await loader.get_context_messages()
+    assert client.calls == 2  # refreshed
+
+
+async def test_get_context_messages_returns_empty_when_list_raises() -> None:
+    class _BoomClient:
+        def list_blobs(self, *_a, **_k):
+            raise RuntimeError("gcs down")
+
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=_BoomClient(), clock=_ManualClock()
+    )
+
+    assert await loader.get_context_messages() == ()
+
+
+async def test_get_context_messages_skips_blob_that_fails_to_download() -> None:
+    client = _FakeStorageClient(
+        blobs=[
+            _FakeBlob(name="context/a.md", content=b"good"),
+            _FakeBlob(name="context/b.md", raises=RuntimeError("perm denied")),
+            _FakeBlob(name="context/c.md", content=b"alsogood"),
+        ]
+    )
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=client, clock=_ManualClock()
+    )
+
+    result = await loader.get_context_messages()
+
+    assert result == ("good", "alsogood")
+
+
+async def test_get_context_messages_truncates_above_byte_budget() -> None:
+    big = b"x" * (MAX_CONTEXT_BYTES + 100)
+    client = _FakeStorageClient(blobs=[_FakeBlob(name="context/a.md", content=big)])
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=client, clock=_ManualClock()
+    )
+
+    result = await loader.get_context_messages()
+
+    assert len(result) == 1
+    assert len(result[0]) <= MAX_CONTEXT_BYTES
+
+
+async def test_get_context_messages_ignores_non_markdown_blobs() -> None:
+    client = _FakeStorageClient(
+        blobs=[
+            _FakeBlob(name="context/a.md", content=b"keep"),
+            _FakeBlob(name="context/notes.txt", content=b"drop"),
+        ]
+    )
+    loader = OpenAIContextLoader(
+        bucket_name="x", client=client, clock=_ManualClock()
+    )
+
+    assert await loader.get_context_messages() == ("keep",)


### PR DESCRIPTION
## Summary

- New `OpenAIContextLoader` reads `.md` files from a versioned GCS bucket (`something-bot-openai-context`) and prepends them as `{"role": "system"}` messages between `SYSTEM_PROMPT` and the user prompt.
- In-process cache with 60s TTL, 32 KiB total budget (excess truncated and logged), GCS failure → empty context (completion still runs).
- Helper script `scripts/context-sync.sh push|pull` syncs the developer's `local-context/` directory to/from `gs://<bucket>/context/`. The `.md` files themselves are gitignored.
- Bucket Terraform: versioning enabled (so accidental local-side deletes don't immediately destroy context), enforced public-access-prevention, uniform bucket-level access. Cloud Run runtime SA gets `objectViewer` only.

## Closes

Closes #26.

## Manual pending TODOs

Captured in #26 — these can't be Terraformed:

- Grant the developer's Google account `objectAdmin` on the new bucket so `gcloud storage rsync` from a laptop works.
- Populate the bucket with starter context (e.g. `personal_facts.md`, `project_state.md`).

## Test plan

- [x] `uv run ruff check src tests` — clean.
- [x] `uv run pytest` — 140 passed (7 new).
- [x] `terraform fmt -check` — clean.
- [ ] Push a `personal_facts.md` with a name; ask the bot \"what's my name?\" — answer should reflect it.
- [ ] Block the runtime SA's `objectViewer` temporarily and confirm the bot still answers (without context) instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)