### PR TITLE
Auto-generate /help from the feature registry (#27)

### DIFF
--- a/src/something_really_bot/features/commands/handler.py
+++ b/src/something_really_bot/features/commands/handler.py
@@ -1,4 +1,4 @@
-"""Static placeholder handlers for ``/start`` and ``/help`` (SPEC §6.6).
+"""``/start`` and ``/help`` command handlers (SPEC §6.6, #27).
 
 Both commands reply to *any* user (QA allowlist does not apply — these are
 the discovery commands new users hit before authorization matters), but
@@ -9,12 +9,12 @@ Telegram's ``@bot_name`` suffix from the ``command`` field, so matching
 ``"/start"`` is sufficient — both ``/start`` and ``/start@SomethingReallyBot``
 arrive here as ``command="/start"``.
 
-The reply text lives in module-level constants so #27 (auto-generated /help
-from the feature registry) can swap the help body without touching the
-matching logic. Handlers are pure: they return :class:`HandlerResult`; the
-webhook performs the send and persistence (#18).
+``/help`` is auto-generated from the feature registry: it walks the
+dispatcher's registered handlers and prints one bullet per handler with
+a non-empty ``description``. See ``routing/help_registry.py``.
 """
 
+from something_really_bot.routing.help_registry import HelpRegistry
 from something_really_bot.routing.types import BotContext, HandlerResult
 from something_really_bot.telegram.models import (
     CommandContent,
@@ -23,7 +23,6 @@ from something_really_bot.telegram.models import (
 )
 
 START_REPLY = "Something Really Bot is online. More features coming soon."
-HELP_REPLY = "Help is not implemented yet. This bot is being rebuilt."
 
 
 class _StaticCommandHandler:
@@ -32,6 +31,8 @@ class _StaticCommandHandler:
     name: str
     command: str
     reply_text: str
+    description: str = ""
+    help_usage: str | None = None
 
     def matches(self, update: ParsedUpdate, _ctx: BotContext) -> bool:
         if not isinstance(update, PrivateMessage):
@@ -48,9 +49,31 @@ class StartCommandHandler(_StaticCommandHandler):
     name = "commands.start"
     command = "/start"
     reply_text = START_REPLY
+    description = "Greeting + intro message."
+    help_usage = "/start"
 
 
-class HelpCommandHandler(_StaticCommandHandler):
+class HelpCommandHandler:
+    """``/help`` command — rendered from the feature registry on each call."""
+
     name = "commands.help"
     command = "/help"
-    reply_text = HELP_REPLY
+    description = "Show this help message."
+    help_usage = "/help"
+
+    def __init__(self, registry: HelpRegistry | None = None) -> None:
+        self._registry = registry or HelpRegistry(lambda: ())
+
+    def matches(self, update: ParsedUpdate, _ctx: BotContext) -> bool:
+        if not isinstance(update, PrivateMessage):
+            return False
+        if not isinstance(update.content, CommandContent):
+            return False
+        return update.content.command == self.command
+
+    async def handle(self, _update: ParsedUpdate, _ctx: BotContext) -> HandlerResult:
+        return HandlerResult(
+            handled=True,
+            handler_name=self.name,
+            reply_text=self._registry.render(),
+        )

--- a/src/something_really_bot/features/example/handler.py
+++ b/src/something_really_bot/features/example/handler.py
@@ -22,6 +22,8 @@ class PingHandler:
     """Reply ``pong`` to ``/ping`` in private, group, and supergroup chats."""
 
     name = "example.ping"
+    description = "Sanity-check liveness — replies 'pong'."
+    help_usage = "/ping"
 
     def matches(self, update: ParsedUpdate, _ctx: BotContext) -> bool:
         """True for ``/ping`` commands in chat types that have a ``from_user``."""

--- a/src/something_really_bot/features/file_storage/handler.py
+++ b/src/something_really_bot/features/file_storage/handler.py
@@ -30,6 +30,8 @@ class FileStorageHandler:
     """Trigger background file download for private-chat file uploads."""
 
     name = "file_storage.download"
+    description = "Send me a photo, document, or voice message — I'll save it."
+    help_usage = "Upload a photo/document/voice"
 
     def matches(self, update: ParsedUpdate, _ctx: BotContext) -> bool:
         if not isinstance(update, PrivateMessage):

--- a/src/something_really_bot/features/hello_world/handler.py
+++ b/src/something_really_bot/features/hello_world/handler.py
@@ -28,6 +28,8 @@ class HelloWorldHandler:
     """Parrots back text messages from authorized QA users."""
 
     name = "hello_world.parrot"
+    description = "Parrot mode for QA users (only active when HELLO_WORLD_MODE=true)."
+    help_usage = "Send a text message"
 
     def matches(self, update: ParsedUpdate, ctx: BotContext) -> bool:
         if not ctx.settings.hello_world_mode:

--- a/src/something_really_bot/features/openai_fallback/handler.py
+++ b/src/something_really_bot/features/openai_fallback/handler.py
@@ -32,6 +32,8 @@ class OpenAIFallbackHandler:
     """Send the message to OpenAI; reply with the response."""
 
     name = "openai_fallback"
+    description = "Chat with me — I'll reply via OpenAI."
+    help_usage = "Send any text message"
 
     def matches(self, update: ParsedUpdate, ctx: BotContext) -> bool:
         if not isinstance(update, PrivateMessage):

--- a/src/something_really_bot/main.py
+++ b/src/something_really_bot/main.py
@@ -45,6 +45,7 @@ from something_really_bot.persistence import (
 )
 from something_really_bot.persistence.bigquery import get_persistence_service
 from something_really_bot.routing.dispatcher import Dispatcher
+from something_really_bot.routing.help_registry import HelpRegistry
 from something_really_bot.routing.types import BotContext, HandlerResult
 from something_really_bot.services.jobs import JobRegistry, UnknownJobError
 from something_really_bot.services.openai_client import get_openai_client
@@ -70,10 +71,14 @@ _logger = get_logger(__name__)
 
 
 def build_default_dispatcher() -> Dispatcher:
-    """Construct the production dispatcher with all enabled handlers."""
+    """Construct the production dispatcher with all enabled handlers.
+
+    Registration order matters: it's both the dispatch precedence and
+    the order the auto-generated ``/help`` (#27) lists features in.
+    """
     dispatcher = Dispatcher()
     dispatcher.register(StartCommandHandler())
-    dispatcher.register(HelpCommandHandler())
+    dispatcher.register(HelpCommandHandler(HelpRegistry(lambda: dispatcher.handlers)))
     dispatcher.register(FileStorageHandler())
     dispatcher.register(HelloWorldHandler())  # gated by settings.hello_world_mode
     dispatcher.register(OpenAIFallbackHandler())

--- a/src/something_really_bot/routing/dispatcher.py
+++ b/src/something_really_bot/routing/dispatcher.py
@@ -46,6 +46,16 @@ class Dispatcher:
         """Append a handler to the match-order list."""
         self._handlers.append(handler)
 
+    @property
+    def handlers(self) -> tuple[Handler, ...]:
+        """Snapshot of the registered handlers in match order.
+
+        Read-only; used by :class:`HelpRegistry` (#27) to enumerate
+        features at ``/help`` time. Mutating the dispatcher after
+        snapshotting won't be reflected in the returned tuple.
+        """
+        return tuple(self._handlers)
+
     def set_fallback(self, handler: Handler) -> None:
         """Set the catch-all handler used when no registered handler matches."""
         self._fallback = handler

--- a/src/something_really_bot/routing/help_registry.py
+++ b/src/something_really_bot/routing/help_registry.py
@@ -1,0 +1,53 @@
+"""Auto-generated ``/help`` text from the feature registry (#27).
+
+Each registered :class:`Handler` exposes a ``description`` and an
+optional ``help_usage``. :class:`HelpRegistry` walks the
+:class:`Dispatcher`'s handlers in registration order and renders one
+bullet per handler.
+
+A handler with an empty ``description`` is omitted (and flagged by the
+production-assembly test in ``tests/unit/test_help_registry.py`` —
+that's the CI enforcement). This keeps debug-only handlers used in
+unit tests from breaking when they don't bother documenting
+themselves.
+"""
+
+from collections.abc import Callable, Iterable
+
+from something_really_bot.routing.types import Handler
+
+
+class HelpRegistry:
+    """Renders the ``/help`` body from a live handler list."""
+
+    HEADER = "Here's what I can do:"
+
+    def __init__(self, get_handlers: Callable[[], Iterable[Handler]]) -> None:
+        self._get_handlers = get_handlers
+
+    def render(self) -> str:
+        """Return the rendered ``/help`` text."""
+        lines: list[str] = [self.HEADER, ""]
+        for handler in self._get_handlers():
+            description = getattr(handler, "description", "").strip()
+            if not description:
+                continue
+            usage = getattr(handler, "help_usage", None)
+            if usage:
+                lines.append(f"• {usage} — {description}")
+            else:
+                lines.append(f"• {description}")
+        if len(lines) == 2:
+            # No documented handlers — give a non-empty body so users still
+            # see something while a fresh deploy registers features.
+            lines.append("• (no documented features yet)")
+        return "\n".join(lines)
+
+
+def collect_descriptions(handlers: Iterable[Handler]) -> dict[str, str]:
+    """Return ``name → description`` for every handler.
+
+    Used by the assembly test to enforce that production handlers all
+    document themselves.
+    """
+    return {h.name: getattr(h, "description", "") for h in handlers}

--- a/tests/unit/features/test_commands_handler.py
+++ b/tests/unit/features/test_commands_handler.py
@@ -9,7 +9,6 @@ from pydantic import SecretStr
 
 from something_really_bot.config import Settings
 from something_really_bot.features.commands.handler import (
-    HELP_REPLY,
     START_REPLY,
     HelpCommandHandler,
     StartCommandHandler,
@@ -72,23 +71,27 @@ def _supergroup_command(command: str) -> SupergroupMessage:
     )
 
 
-@pytest.mark.parametrize(
-    ("handler_cls", "command", "expected_reply"),
-    [
-        (StartCommandHandler, "/start", START_REPLY),
-        (HelpCommandHandler, "/help", HELP_REPLY),
-    ],
-)
-async def test_command_in_private_chat_returns_static_reply(
-    handler_cls: type, command: str, expected_reply: str
-) -> None:
-    handler = handler_cls()
+async def test_start_handler_returns_static_reply() -> None:
+    handler = StartCommandHandler()
 
-    result = await handler.handle(_private_command(command), _ctx())
+    result = await handler.handle(_private_command("/start"), _ctx())
 
     assert result.handled is True
-    assert result.handler_name == handler_cls.name
-    assert result.reply_text == expected_reply
+    assert result.handler_name == StartCommandHandler.name
+    assert result.reply_text == START_REPLY
+
+
+async def test_help_handler_returns_rendered_registry_body() -> None:
+    """``/help`` body comes from the injected HelpRegistry (#27)."""
+    handler = HelpCommandHandler()
+
+    result = await handler.handle(_private_command("/help"), _ctx())
+
+    assert result.handled is True
+    assert result.handler_name == HelpCommandHandler.name
+    # Default registry is empty → placeholder line is present.
+    assert "Here's what I can do:" in (result.reply_text or "")
+    assert "(no documented features yet)" in (result.reply_text or "")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_help_registry.py
+++ b/tests/unit/test_help_registry.py
@@ -19,9 +19,7 @@ from something_really_bot.routing.types import BotContext, HandlerResult
 
 
 class _DummyHandler:
-    def __init__(
-        self, *, name: str, description: str, help_usage: str | None = None
-    ) -> None:
+    def __init__(self, *, name: str, description: str, help_usage: str | None = None) -> None:
         self.name = name
         self.description = description
         self.help_usage = help_usage
@@ -75,9 +73,7 @@ def test_render_pulls_fresh_handlers_each_call() -> None:
     registry = HelpRegistry(lambda: handlers)
 
     before = registry.render()
-    handlers.append(
-        _DummyHandler(name="b", description="second", help_usage="/b")
-    )
+    handlers.append(_DummyHandler(name="b", description="second", help_usage="/b"))
     after = registry.render()
 
     assert "second" not in before

--- a/tests/unit/test_help_registry.py
+++ b/tests/unit/test_help_registry.py
@@ -1,0 +1,110 @@
+"""Tests for the auto-generated ``/help`` rendering (#27).
+
+Covers:
+- HelpRegistry.render() against a stubbed handler list.
+- Adding a new handler with a description surfaces in /help with no
+  command-handler changes.
+- Every handler registered by ``build_default_dispatcher`` has a
+  non-empty description (CI enforcement for the contract).
+"""
+
+from typing import Any
+
+from something_really_bot.main import build_default_dispatcher
+from something_really_bot.routing.help_registry import (
+    HelpRegistry,
+    collect_descriptions,
+)
+from something_really_bot.routing.types import BotContext, HandlerResult
+
+
+class _DummyHandler:
+    def __init__(
+        self, *, name: str, description: str, help_usage: str | None = None
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.help_usage = help_usage
+
+    def matches(self, _u: Any, _c: BotContext) -> bool:
+        return False
+
+    async def handle(self, _u: Any, _c: BotContext) -> HandlerResult:
+        return HandlerResult(handled=False)
+
+
+def test_render_lists_documented_handlers_in_registration_order() -> None:
+    handlers = [
+        _DummyHandler(name="a", description="Greeting.", help_usage="/a"),
+        _DummyHandler(name="b", description="Help body.", help_usage="/b"),
+        _DummyHandler(name="c", description="Send a thing.", help_usage="Upload"),
+        _DummyHandler(name="d", description="Just chat."),  # no usage
+    ]
+    registry = HelpRegistry(lambda: handlers)
+
+    body = registry.render()
+
+    lines = body.splitlines()
+    assert lines[0] == "Here's what I can do:"
+    assert lines[1] == ""
+    assert lines[2] == "• /a — Greeting."
+    assert lines[3] == "• /b — Help body."
+    assert lines[4] == "• Upload — Send a thing."
+    assert lines[5] == "• Just chat."
+
+
+def test_render_skips_handlers_with_empty_description() -> None:
+    handlers = [
+        _DummyHandler(name="documented", description="visible", help_usage="/d"),
+        _DummyHandler(name="silent", description="", help_usage="/s"),
+    ]
+    registry = HelpRegistry(lambda: handlers)
+
+    body = registry.render()
+
+    assert "visible" in body
+    assert "silent" not in body
+    assert "/s" not in body
+
+
+def test_render_pulls_fresh_handlers_each_call() -> None:
+    """A handler added after construction shows up on the next render."""
+    handlers: list[_DummyHandler] = [
+        _DummyHandler(name="a", description="first", help_usage="/a"),
+    ]
+    registry = HelpRegistry(lambda: handlers)
+
+    before = registry.render()
+    handlers.append(
+        _DummyHandler(name="b", description="second", help_usage="/b")
+    )
+    after = registry.render()
+
+    assert "second" not in before
+    assert "second" in after
+
+
+def test_render_returns_placeholder_when_nothing_documented() -> None:
+    registry = HelpRegistry(lambda: [])
+
+    body = registry.render()
+
+    assert "(no documented features yet)" in body
+
+
+# --------------------------------------------------------------------------- #
+# Production-assembly enforcement: every registered handler has a description.
+# This is the CI gate that closes the loop on #27's acceptance criterion.
+# --------------------------------------------------------------------------- #
+
+
+def test_every_default_handler_has_a_non_empty_description() -> None:
+    dispatcher = build_default_dispatcher()
+    descriptions = collect_descriptions(dispatcher.handlers)
+
+    missing = [name for name, desc in descriptions.items() if not desc.strip()]
+
+    assert not missing, (
+        f"Handlers missing a description (required by #27): {missing}. "
+        "Add `description: str = ...` to the handler class."
+    )


### PR DESCRIPTION
## Summary

- New `HelpRegistry` walks the dispatcher's registered handlers and renders one bullet per handler with a non-empty `description`. Registration order = match order = /help order.
- Each handler now declares `description: str` and optional `help_usage: str | None` as class attributes — adding a feature surfaces it in /help with no commands-module changes.
- CI-enforcement test (`test_every_default_handler_has_a_non_empty_description`) fails the build if a production-registered handler skips documentation.

## Closes

Closes #27.

## Notes

- Handlers used only in unit tests (mock handlers, etc.) don't need descriptions — the enforcement is scoped to `build_default_dispatcher()`.
- Ordering choice: registration order. Documented in `build_default_dispatcher` docstring.
- Out of scope (per the issue): i18n, per-user filtering, BotFather autocomplete (`setMyCommands`).

## Test plan

- [x] `uv run ruff check src tests` — clean.
- [x] `uv run pytest` — 138 passed (5 new for HelpRegistry).
- [ ] Send `/help` to the deployed bot — output reflects all registered handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)