### PR TITLE
Structured logs + Cloud Logging alerting (#28)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,75 @@
+# Observability
+
+Cloud Run streams the bot container's stdout into Cloud Logging. The
+app emits **one JSON object per log line** so the lines arrive in Cloud
+Logging fully structured rather than as opaque text.
+
+Source: `src/something_really_bot/logging.py`. Terraform for log-based
+metrics and alert policies lives in `infra/terraform/logging.tf` (#28).
+
+## Log shape
+
+Every line is a JSON object with at minimum:
+
+| Field | Type | Notes |
+|---|---|---|
+| `severity` | string | Cloud Logging severity. Cloud Run reads it off the JSON and stamps the log entry. One of `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`. |
+| `message` | string | The formatted log message. |
+| `logger` | string | Python logger name (`something_really_bot.<module>`). |
+| `exception` | string | Stack trace when the call used `logger.exception(...)` or set `exc_info=True`. |
+| `update_id` | int | Telegram update ID (when in the webhook flow). |
+| `bot_id` | string | Always `default` today; multi-bot lands later. |
+| `handler` / `handler_name` | string | Name of the matched handler. |
+| `route` | string | HTTP path (when known). |
+| `error` | string | Pre-formatted error message — already on the line, doesn't need exception parsing. |
+
+Anything passed via `logger.<level>("foo", extra={"k": "v"})` is merged
+into the JSON object at the top level, so Cloud Logging exposes it as
+`jsonPayload.k` and structured filters work straight away.
+
+## Querying
+
+In Cloud Logging, the log entries are scoped by `resource.type` and
+`resource.labels.service_name`:
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="something-really-bot-cloudrun"
+```
+
+Useful filters built on the JSON payload:
+
+| Question | Filter |
+|---|---|
+| All errors in the last hour | `severity>=ERROR` |
+| One specific update | `jsonPayload.update_id=42` |
+| Telegram send failures only | `jsonPayload.message="telegram_send_failed"` |
+| Webhook calls that never matched a handler | `jsonPayload.message="no_handler_matched"` |
+| Scheduled-job runs (success or failure) | `jsonPayload.message=~"^finco_daily_stats_\|^tiktok_reminder_"` |
+| Unhandled handler exceptions | `jsonPayload.message="handler_raised"` |
+
+## Alerting
+
+`infra/terraform/logging.tf` provisions:
+
+- A **log-based metric** `something-really-bot-cloudrun-errors`
+  counting `severity>=ERROR` lines on this service.
+- An **email notification channel** (when `var.alerts_email` is set —
+  empty by default so applies in fresh projects don't 4xx on missing
+  notification routing).
+- An **alert policy** that fires when the metric exceeds
+  `var.alerts_error_threshold` (default 5) over
+  `var.alerts_error_window_seconds` (default 300 = 5 min).
+
+Configure by setting `alerts_email` in `environments/prod.tfvars`. The
+metric is created regardless so it accumulates history.
+
+## What's not in this iteration
+
+Per #28 acceptance criteria — explicit out-of-scope:
+
+- SLOs and on-call rotations.
+- External observability vendors (Datadog, Grafana Cloud, etc.).
+- Full dashboards with QPS / p95 latency / cold-start counts. Cloud
+  Run's built-in metrics page covers the basics interactively; a
+  Terraform-managed dashboard is a follow-up.

--- a/infra/terraform/logging.tf
+++ b/infra/terraform/logging.tf
@@ -1,0 +1,93 @@
+# Cloud Logging + Monitoring scaffolding (#28).
+#
+# Cloud Run already streams stdout to Cloud Logging — the app emits
+# structured JSON (see src/something_really_bot/logging.py) and Cloud
+# Logging promotes the top-level `severity` field automatically. This
+# file adds:
+#
+#   - A log-based counter metric for ERROR-or-worse log entries on this
+#     service, used by the alert policy below.
+#   - An email notification channel (when var.alerts_email is set).
+#   - An alert policy that pages out the channel when the error count
+#     exceeds the configured threshold over a rolling window.
+#
+# When `var.alerts_email` is empty the policy + channel are skipped, so
+# applying this in a project without an operator email still succeeds.
+
+locals {
+  # Filter for the log-based metric: anything from the bot's Cloud Run
+  # service whose severity is ERROR or worse. Stdout JSON with a
+  # top-level "severity" field is what surfaces here — see
+  # src/something_really_bot/logging.py::StructuredJsonFormatter.
+  bot_error_log_filter = <<EOT
+resource.type="cloud_run_revision"
+resource.labels.service_name="${var.cloudrun_service_name}"
+severity>=ERROR
+EOT
+
+  alerts_enabled = length(trimspace(var.alerts_email)) > 0
+}
+
+resource "google_logging_metric" "bot_errors" {
+  project     = var.project_id
+  name        = "${var.cloudrun_service_name}-errors"
+  description = "Count of ERROR-or-worse log entries from the bot Cloud Run service (#28)."
+  filter      = local.bot_error_log_filter
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Bot Cloud Run error logs"
+  }
+
+  depends_on = [google_project_service.enabled]
+}
+
+resource "google_monitoring_notification_channel" "email" {
+  count = local.alerts_enabled ? 1 : 0
+
+  project      = var.project_id
+  display_name = "Something Dashboard bot — operator email"
+  type         = "email"
+
+  labels = {
+    email_address = var.alerts_email
+  }
+
+  depends_on = [google_project_service.enabled]
+}
+
+resource "google_monitoring_alert_policy" "bot_error_rate" {
+  count = local.alerts_enabled ? 1 : 0
+
+  project      = var.project_id
+  display_name = "Something Dashboard bot — error rate"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "Bot Cloud Run ERROR-or-worse log entries exceed threshold"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.bot_errors.name}\" AND resource.type=\"cloud_run_revision\""
+      duration        = "${var.alerts_error_window_seconds}s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.alerts_error_threshold
+
+      aggregations {
+        alignment_period   = "${var.alerts_error_window_seconds}s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
+
+  documentation {
+    content   = "Bot logged more than ${var.alerts_error_threshold} ERROR-or-worse entries in the last ${var.alerts_error_window_seconds}s. Check Cloud Logging for stack traces, then inspect bot_responses / processing_events in BigQuery."
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_project_service.enabled]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -7,6 +7,8 @@ locals {
     "cloudscheduler.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
     "serviceusage.googleapis.com",

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -89,3 +89,21 @@ variable "openai_api_key_secret_name" {
   type        = string
   default     = "OPENAI_API_KEY"
 }
+
+variable "alerts_email" {
+  description = "Email address that receives Cloud Monitoring alerts for the bot (#28). When empty, the email notification channel and the alert policy are skipped — the log-based metric still gets created so it accumulates a history."
+  type        = string
+  default     = ""
+}
+
+variable "alerts_error_threshold" {
+  description = "Trigger the bot-error-rate alert when the log-based metric exceeds this count in the rolling window (#28)."
+  type        = number
+  default     = 5
+}
+
+variable "alerts_error_window_seconds" {
+  description = "Rolling window over which alerts_error_threshold is evaluated, in seconds (#28). Default 300 = 5 minutes."
+  type        = number
+  default     = 300
+}

--- a/src/something_really_bot/logging.py
+++ b/src/something_really_bot/logging.py
@@ -1,24 +1,118 @@
-"""Minimal logging helper.
+"""Structured-JSON logging configured for Cloud Logging (#28).
 
-Cloud Run scrapes the container's stdout/stderr into Cloud Logging, so
-plain :mod:`logging` is sufficient for the rebuild's first iterations.
-Structured JSON output, log sinks, and Cloud Monitoring alerts are tracked
-in the dedicated backlog issue.
+Cloud Run scrapes the container's stdout into Cloud Logging. When a
+single line of stdout is a JSON object containing a top-level
+``severity`` field, Cloud Logging promotes it to the entry severity and
+indexes the remaining fields as ``jsonPayload`` — making them queryable
+in log filters and usable as labels for log-based metrics.
+
+Reference: https://cloud.google.com/logging/docs/structured-logging
+
+Loggers in this project always call ``get_logger(__name__).<level>(msg, extra={...})``;
+the ``extra`` dict is merged into the JSON payload. Reserved Python
+``LogRecord`` attributes are excluded automatically so callers never
+have to think about clashes.
 """
 
+import json
 import logging
+import os
+from typing import Any
 
-_DEFAULT_FORMAT = "%(levelname)s %(name)s %(message)s"
+_SEVERITY_BY_LEVELNAME: dict[str, str] = {
+    "DEBUG": "DEBUG",
+    "INFO": "INFO",
+    "WARNING": "WARNING",
+    "ERROR": "ERROR",
+    "CRITICAL": "CRITICAL",
+}
+
+# Attributes the logging module attaches to every LogRecord — we must
+# not bubble them into the JSON payload as user-extras.
+_RESERVED_LOGRECORD_ATTRS: frozenset[str] = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
+
+class StructuredJsonFormatter(logging.Formatter):
+    """Render each :class:`logging.LogRecord` as a single JSON line.
+
+    The output line contains, at minimum:
+
+    - ``severity`` — Cloud Logging severity (DEBUG/INFO/WARNING/ERROR/CRITICAL).
+    - ``message`` — the formatted message.
+    - ``logger`` — the logger name.
+
+    Any non-reserved attributes (i.e. things passed via ``extra=``) are
+    merged at the top level so they're queryable via Cloud Logging's
+    structured search (``jsonPayload.<key>``).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003
+        payload: dict[str, Any] = {
+            "severity": _SEVERITY_BY_LEVELNAME.get(record.levelname, record.levelname),
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_LOGRECORD_ATTRS:
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+        return json.dumps(payload, default=str)
+
+
+_DEFAULT_LEVEL = "INFO"
+
+
+def configure_logging(level: str | None = None) -> None:
+    """Install the structured JSON handler on the root logger.
+
+    Idempotent: re-configuring replaces the active handlers so test
+    teardown and module re-imports don't double-log.
+    """
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    handler = logging.StreamHandler()
+    handler.setFormatter(StructuredJsonFormatter())
+    root.addHandler(handler)
+    root.setLevel(level or os.getenv("LOG_LEVEL", _DEFAULT_LEVEL).upper())
 
 
 def get_logger(name: str) -> logging.Logger:
     """Return a configured logger for ``name``.
 
-    The first call installs a basic stream handler at INFO level. Cloud
-    Run treats stdout lines as log entries and recognises ``severity``
-    levels embedded in the message; until #28 lands we rely on the textual
-    level marker.
+    The first call installs the structured-JSON handler on the root
+    logger. Subsequent calls are cheap.
     """
     if not logging.getLogger().handlers:
-        logging.basicConfig(level=logging.INFO, format=_DEFAULT_FORMAT)
+        configure_logging()
     return logging.getLogger(name)

--- a/src/something_really_bot/main.py
+++ b/src/something_really_bot/main.py
@@ -34,7 +34,7 @@ from something_really_bot.features.hello_world.handler import HelloWorldHandler
 from something_really_bot.features.openai_fallback.handler import OpenAIFallbackHandler
 from something_really_bot.features.tiktok_reminder.handler import TikTokReminderJob
 from something_really_bot.file_storage.fetcher import get_file_fetcher
-from something_really_bot.logging import get_logger
+from something_really_bot.logging import configure_logging, get_logger
 from something_really_bot.persistence import (
     EventRecord,
     FileRecord,
@@ -99,7 +99,12 @@ job_registry: JobRegistry = build_default_job_registry()
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    """Eagerly build :class:`Settings` so missing required config crashes the boot."""
+    """Eagerly build :class:`Settings` so missing required config crashes the boot.
+
+    Also installs the structured JSON log handler so Cloud Logging picks
+    up severity and ``jsonPayload`` fields (#28).
+    """
+    configure_logging()
     get_settings()
     yield
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,138 @@
+"""Tests for :mod:`something_really_bot.logging` (#28).
+
+Asserts the JSON shape Cloud Logging expects:
+- ``severity`` at the top level (so Cloud Run promotes it).
+- ``message`` and ``logger`` always present.
+- Caller-provided ``extra=`` keys merged at the top level (so they
+  become ``jsonPayload.<key>`` and structured filters work).
+- Reserved LogRecord attributes never bleed into the payload.
+- ``exc_info`` produces an ``exception`` field.
+"""
+
+import io
+import json
+import logging
+
+import pytest
+
+from something_really_bot.logging import (
+    StructuredJsonFormatter,
+    configure_logging,
+    get_logger,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logging():
+    """Tear down the structured handler between tests so we don't leak state."""
+    yield
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+
+def _format(record_kwargs: dict) -> dict:
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name=record_kwargs["name"],
+        level=record_kwargs["level"],
+        pathname=__file__,
+        lineno=10,
+        msg=record_kwargs["msg"],
+        args=None,
+        exc_info=record_kwargs.get("exc_info"),
+    )
+    for key, value in record_kwargs.get("extra", {}).items():
+        setattr(record, key, value)
+    return json.loads(formatter.format(record))
+
+
+def test_format_includes_severity_message_and_logger() -> None:
+    payload = _format({"name": "foo.bar", "level": logging.INFO, "msg": "hello"})
+
+    assert payload["severity"] == "INFO"
+    assert payload["message"] == "hello"
+    assert payload["logger"] == "foo.bar"
+
+
+def test_format_promotes_extras_to_top_level() -> None:
+    payload = _format({
+        "name": "foo",
+        "level": logging.WARNING,
+        "msg": "noisy",
+        "extra": {"update_id": 42, "bot_id": "default", "route": "/webhook"},
+    })
+
+    assert payload["severity"] == "WARNING"
+    assert payload["update_id"] == 42
+    assert payload["bot_id"] == "default"
+    assert payload["route"] == "/webhook"
+
+
+def test_format_excludes_reserved_logrecord_attributes() -> None:
+    payload = _format({
+        "name": "foo",
+        "level": logging.INFO,
+        "msg": "x",
+        "extra": {"update_id": 1},
+    })
+
+    for reserved in ("pathname", "lineno", "process", "msecs"):
+        assert reserved not in payload, f"reserved key {reserved!r} leaked into payload"
+
+
+def test_format_includes_exception_when_exc_info_set() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        exc_info = sys.exc_info()
+
+    payload = _format({
+        "name": "foo",
+        "level": logging.ERROR,
+        "msg": "oops",
+        "exc_info": exc_info,
+    })
+
+    assert payload["severity"] == "ERROR"
+    assert "boom" in payload["exception"]
+    assert "ValueError" in payload["exception"]
+
+
+def test_configure_logging_installs_json_handler_on_root() -> None:
+    configure_logging()
+
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+    assert isinstance(handlers[0].formatter, StructuredJsonFormatter)
+
+
+def test_configure_logging_is_idempotent() -> None:
+    """Re-configuring replaces handlers rather than stacking them."""
+    configure_logging()
+    configure_logging()
+    configure_logging()
+
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+
+
+def test_get_logger_writes_json_line_to_stderr() -> None:
+    configure_logging()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(StructuredJsonFormatter())
+    log = get_logger("test.json_line")
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    log.propagate = False
+
+    log.info("ping", extra={"update_id": 7})
+
+    line = buf.getvalue().strip()
+    payload = json.loads(line)
+    assert payload["severity"] == "INFO"
+    assert payload["message"] == "ping"
+    assert payload["update_id"] == 7

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -56,12 +56,14 @@ def test_format_includes_severity_message_and_logger() -> None:
 
 
 def test_format_promotes_extras_to_top_level() -> None:
-    payload = _format({
-        "name": "foo",
-        "level": logging.WARNING,
-        "msg": "noisy",
-        "extra": {"update_id": 42, "bot_id": "default", "route": "/webhook"},
-    })
+    payload = _format(
+        {
+            "name": "foo",
+            "level": logging.WARNING,
+            "msg": "noisy",
+            "extra": {"update_id": 42, "bot_id": "default", "route": "/webhook"},
+        }
+    )
 
     assert payload["severity"] == "WARNING"
     assert payload["update_id"] == 42
@@ -70,12 +72,14 @@ def test_format_promotes_extras_to_top_level() -> None:
 
 
 def test_format_excludes_reserved_logrecord_attributes() -> None:
-    payload = _format({
-        "name": "foo",
-        "level": logging.INFO,
-        "msg": "x",
-        "extra": {"update_id": 1},
-    })
+    payload = _format(
+        {
+            "name": "foo",
+            "level": logging.INFO,
+            "msg": "x",
+            "extra": {"update_id": 1},
+        }
+    )
 
     for reserved in ("pathname", "lineno", "process", "msecs"):
         assert reserved not in payload, f"reserved key {reserved!r} leaked into payload"
@@ -89,12 +93,14 @@ def test_format_includes_exception_when_exc_info_set() -> None:
 
         exc_info = sys.exc_info()
 
-    payload = _format({
-        "name": "foo",
-        "level": logging.ERROR,
-        "msg": "oops",
-        "exc_info": exc_info,
-    })
+    payload = _format(
+        {
+            "name": "foo",
+            "level": logging.ERROR,
+            "msg": "oops",
+            "exc_info": exc_info,
+        }
+    )
 
     assert payload["severity"] == "ERROR"
     assert "boom" in payload["exception"]


### PR DESCRIPTION
## Summary

- Emit one JSON line per log record. \`severity\` lands at the top of the payload so Cloud Run promotes it on ingest, and any \`extra={...}\` kwargs become \`jsonPayload.<key>\` for structured filters.
- Provision a log-based metric (\`something-really-bot-cloudrun-errors\`) plus a Cloud Monitoring alert policy that fires when ERROR-or-worse entries exceed \`alerts_error_threshold\` (default 5) over \`alerts_error_window_seconds\` (default 300s). Email channel + alert policy are gated on a non-empty \`alerts_email\` variable.
- Adds \`logging.googleapis.com\` and \`monitoring.googleapis.com\` to required APIs.
- \`docs/observability.md\` documents the log shape, query recipes, and what's intentionally out of scope (SLOs, vendor agents, full dashboards).

## Closes

Closes #28.

## Notes

- The metric is always provisioned so it accrues history even when \`alerts_email\` is empty; only the policy + channel are gated.
- \`configure_logging()\` is idempotent so test teardown and module reloads don't stack handlers.

## Test plan

- [x] \`uv run ruff check src tests\` — clean.
- [x] \`uv run pytest\` — 140 passed (7 new).
- [x] \`terraform fmt -check\` — clean.
- [ ] After applying with \`alerts_email\` set: trigger 6+ ERROR logs and confirm the alert email arrives.
- [ ] Cloud Logging query \`jsonPayload.update_id=<n>\` returns the expected line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)