### PR TITLE
Terraform CI: tflint + real plan with read-only SA (#29)

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+env:
+  TERRAFORM_VERSION: 1.15.3
+  TFLINT_VERSION: v0.59.1
+
 jobs:
   python-checks:
     name: Python — ruff + pytest
@@ -33,7 +37,7 @@ jobs:
         run: uv run pytest -q
 
   terraform-checks:
-    name: Terraform — fmt + validate
+    name: Terraform — fmt + validate + tflint
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,7 +49,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.15.3
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
       - name: terraform fmt -check
@@ -56,3 +60,124 @@ jobs:
 
       - name: terraform validate
         run: terraform validate
+
+      - name: Install tflint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: ${{ env.TFLINT_VERSION }}
+
+      - name: tflint --init
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: tflint
+        run: tflint --recursive --format=compact
+
+  terraform-plan-preflight:
+    name: Terraform plan preflight (planner SA configured?)
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check that planner WIF secrets are set
+        id: check
+        env:
+          WIF_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          PLANNER_SA: ${{ secrets.GCP_PLANNER_SERVICE_ACCOUNT }}
+        run: |
+          if [ -n "${WIF_PROVIDER}" ] && [ -n "${PLANNER_SA}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Terraform plan skipped: GCP_WORKLOAD_IDENTITY_PROVIDER and/or GCP_PLANNER_SERVICE_ACCOUNT are unset. After applying #29's Terraform, set GCP_PLANNER_SERVICE_ACCOUNT to the planner SA email to enable plan-on-PR."
+          fi
+
+  terraform-plan:
+    name: Terraform — plan
+    runs-on: ubuntu-latest
+    needs: [terraform-checks, terraform-plan-preflight]
+    if: needs.terraform-plan-preflight.outputs.enabled == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: infra/terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to GCP via WIF (planner SA)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PLANNER_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: terraform init (with backend)
+        run: terraform init -input=false
+
+      - name: terraform plan
+        id: plan
+        run: |
+          set +e
+          terraform plan \
+            -no-color \
+            -input=false \
+            -var-file=environments/prod.tfvars \
+            -out=tfplan \
+            -detailed-exitcode \
+            > plan.stdout 2> plan.stderr
+          exit_code=$?
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+          # 0 = no diff, 2 = diff, anything else = error
+          if [ "$exit_code" -eq 1 ]; then
+            cat plan.stderr
+            exit 1
+          fi
+
+      - name: Render plan summary
+        id: summary
+        run: |
+          terraform show -no-color tfplan > plan.txt
+          {
+            echo "## Terraform plan"
+            echo
+            echo "Exit code: \`${{ steps.plan.outputs.exit_code }}\` (\`0\`=no changes, \`2\`=changes, \`1\`=error)"
+            echo
+            echo "<details><summary>Plan output (truncated to 60 KiB)</summary>"
+            echo
+            echo '```hcl'
+            head -c 61440 plan.txt
+            echo
+            echo '```'
+            echo
+            echo "</details>"
+          } > plan-summary.md
+          cat plan-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment plan on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync(
+              'infra/terraform/plan-summary.md',
+              'utf8',
+            );
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number, body,
+            });

--- a/infra/terraform/.tflint.hcl
+++ b/infra/terraform/.tflint.hcl
@@ -1,0 +1,16 @@
+// tflint configuration for the bot's Terraform (#29).
+//
+// Pulls in the Google ruleset for provider-aware checks (deprecated
+// resource attrs, invalid region/zone values, etc.) on top of the
+// built-in core rules.
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.30.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -100,19 +100,56 @@ echo -n "<random-secret-string>" \
 Do the same for `telegram-bot-token-default`, `telegram-qa-users`, and
 `OPENAI_API_KEY` if their values are not already set.
 
-## Structural validation (CI-friendly)
+## CI gates (#29)
 
-These commands only check syntax / refs and don't talk to GCP:
+The repository's GitHub Actions `_checks.yml` workflow runs five gates on
+every PR that touches anything (and as a prerequisite of the `deploy`
+job on pushes to `master`):
+
+1. `terraform fmt -check -recursive`
+2. `terraform init -backend=false -input=false`
+3. `terraform validate`
+4. `tflint --recursive` (with the `google` provider ruleset — see
+   `.tflint.hcl`)
+5. **Real `terraform plan`** against `something-bot-338300` via WIF
+   (planner SA, strictly read-only). Plan output is posted as a PR
+   comment and to the workflow `$GITHUB_STEP_SUMMARY`.
+
+Gate (5) is gated on `GCP_PLANNER_SERVICE_ACCOUNT` being set as a repo
+secret; without it the plan job is skipped (a notice surfaces in the
+run-list), but gates 1–4 still run.
+
+To enable plan-on-PR after applying:
+
+```bash
+terraform output -raw planner_service_account_email
+# put this value into GitHub → Settings → Secrets → Actions →
+#   GCP_PLANNER_SERVICE_ACCOUNT
+```
+
+`GCP_WORKLOAD_IDENTITY_PROVIDER` is reused (same provider as the
+deployer).
+
+### Deploy gating
+
+`deploy.yml` chains `deploy → preflight → checks`; if any gate above
+fails on `master`, the deploy job is skipped and the workflow exits
+non-zero so it's visible at the run-list level. Failing-loud is
+preferable to silent infra drift.
+
+### Running locally
+
+The same commands run cleanly locally with `gcloud auth
+application-default login` against the project:
 
 ```bash
 terraform fmt -check -recursive
-terraform init -backend=false
+terraform init -backend=false -input=false
 terraform validate
+tflint --init && tflint --recursive --format=compact
+terraform init                          # real backend
+terraform plan -var-file=environments/prod.tfvars
 ```
-
-The repository's GitHub Actions workflow (added in #9) runs these on every
-PR. A separate backlog issue tracks adding `tflint` and a real `plan` step
-that runs against the project.
 
 ## Cloud Run settings (RFC for SPEC §18.3)
 
@@ -157,6 +194,4 @@ Manager resource will be planned for the new bot automatically.
 - BigQuery dataset / tables — #18.
 - Cloud Scheduler endpoints — #22.
 - CI deployment workflow — #9.
-- Cloud Logging sinks / alerting — see the dedicated backlog issue.
-- Terraform CI checks (fmt / validate / tflint / real plan) — see the
-  dedicated backlog issue.
+- Cloud Logging sinks / alerting — #28.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -20,6 +20,15 @@ locals {
     "roles/run.admin",
   ]
 
+  # Read-only roles for the planner SA used by `terraform plan` in CI
+  # (#29). The planner must be able to *read* every resource type the
+  # plan touches (IAM, secrets, Cloud Run, etc.) but never mutate them.
+  planner_project_roles = [
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/secretmanager.viewer",
+  ]
+
   webhook_secret_ids = {
     for key, _ in var.bots : key => "telegram-webhook-secret-${key}"
   }
@@ -88,6 +97,15 @@ resource "google_service_account" "deployer" {
   depends_on = [google_project_service.enabled]
 }
 
+resource "google_service_account" "planner" {
+  project      = var.project_id
+  account_id   = "something-bot-planner-sa"
+  display_name = "Something Dashboard bot — GitHub Actions Terraform planner"
+  description  = "Assumed by GitHub Actions via WIF to run read-only `terraform plan` (#29). Strictly read-only — see locals.planner_project_roles."
+
+  depends_on = [google_project_service.enabled]
+}
+
 # --------------------------------------------------------------------------- #
 # Workload Identity Federation for GitHub Actions
 # --------------------------------------------------------------------------- #
@@ -133,6 +151,20 @@ resource "google_project_iam_member" "deployer" {
   project = var.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_service_account_iam_member" "planner_wif" {
+  service_account_id = google_service_account.planner.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+}
+
+resource "google_project_iam_member" "planner" {
+  for_each = toset(local.planner_project_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.planner.email}"
 }
 
 # --------------------------------------------------------------------------- #

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -13,6 +13,11 @@ output "deployer_service_account_email" {
   value       = google_service_account.deployer.email
 }
 
+output "planner_service_account_email" {
+  description = "Read-only service account assumed by GitHub Actions for `terraform plan` (#29). Goes into the workflow as `service_account` for the `google-github-actions/auth` step on the plan job."
+  value       = google_service_account.planner.email
+}
+
 output "workload_identity_provider" {
   description = "Fully-qualified WIF provider resource name. Goes into the workflow as `workload_identity_provider` for the `google-github-actions/auth` step."
   value       = google_iam_workload_identity_pool_provider.github.name


### PR DESCRIPTION
## Summary

Five gates now run on every PR that touches infra/terraform/ (and as a prerequisite of the deploy job on pushes to master):

1. \`terraform fmt -check -recursive\`
2. \`terraform init -backend=false -input=false\`
3. \`terraform validate\`
4. \`tflint --recursive\` (Google provider ruleset, pinned in \`.tflint.hcl\`)
5. \`terraform plan\` against \`something-bot-338300\` via WIF using a new strictly read-only planner SA. Plan output goes to \`\$GITHUB_STEP_SUMMARY\` and, on PRs, is posted as a PR comment.

Gate (5) is gated on the new \`GCP_PLANNER_SERVICE_ACCOUNT\` repo secret. Without it the plan job is skipped (notice in run-list) but gates 1–4 still run — so a freshly cloned fork doesn't fail.

## Closes

Closes #29.

## Manual pending TODOs

After merge:

1. \`terraform apply\` to create the planner SA + WIF binding.
2. \`terraform output -raw planner_service_account_email\` → set as \`GCP_PLANNER_SERVICE_ACCOUNT\` in repo secrets. \`GCP_WORKLOAD_IDENTITY_PROVIDER\` is reused from the deployer setup.
3. (Optional) Configure GitHub branch protection to require the \`Terraform — plan\` check before merge.

## Notes

- Planner SA roles: \`viewer\` + \`iam.securityReviewer\` + \`secretmanager.viewer\` — exactly what the issue specified.
- Deploy gating stays structural: \`deploy → preflight → checks\` already short-circuits on any checks failure. Documented in README for clarity.

## Test plan

- [x] \`terraform fmt -check\` — clean.
- [x] \`uv run pytest\` — 133 passed (Python suite unchanged).
- [ ] PR run reveals the plan comment posted with the diff.
- [ ] Fresh fork without planner secret: gates 1–4 still pass; gate 5 surfaces a notice but doesn't fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)