### PR TITLE
Shared Cloud SQL Postgres wrapper (#31)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,9 @@ jobs:
         #   - TELEGRAM_BOT_TOKEN     (used by TelegramClient.send_message, #15)
         #   - TELEGRAM_QA_USERS      (parsed into the QA allowlist, #15)
         #   - OPENAI_API_KEY         (used by the OpenAI fallback handler, #23)
+        #   - POSTGRES_DSN           (shared Cloud SQL connection string, #31; secret may
+        #                             not yet exist in fresh deploys — set --set-secrets to
+        #                             drop the entry if absent)
         # Each --set-secrets value must already have at least one Secret
         # Manager version or the deploy will fail.
         run: |
@@ -107,7 +110,7 @@ jobs:
             --region="${REGION}" \
             --image="${{ steps.image.outputs.sha_tag }}" \
             --service-account="${RUNTIME_SA}" \
-            --set-secrets="TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-default:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-default:latest,TELEGRAM_QA_USERS=telegram-qa-users:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest" \
+            --set-secrets="TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-default:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-default:latest,TELEGRAM_QA_USERS=telegram-qa-users:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,POSTGRES_DSN=POSTGRES_DSN:latest" \
             --set-env-vars="SCHEDULER_SERVICE_ACCOUNT_EMAIL=something-bot-scheduler-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
             --quiet
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,15 +93,29 @@ jobs:
             ${{ steps.image.outputs.latest_tag }}
           provenance: false
 
+      - name: Resolve Cloud SQL instance connection name
+        # POSTGRES_INSTANCE holds "project:region:instance" for the shared
+        # Cloud SQL DB (#31). We read the latest version here so we can
+        # pass it to --add-cloudsql-instances; the runtime *also* gets it
+        # as an env var via --set-secrets so PostgresStorage can route
+        # through the Auth Proxy socket at /cloudsql/<conn>/.
+        id: cloudsql
+        run: |
+          conn=$(gcloud secrets versions access latest \
+            --project="${PROJECT_ID}" --secret=POSTGRES_INSTANCE)
+          echo "::add-mask::${conn}"
+          echo "connection=${conn}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to Cloud Run
         # Secrets injected as env vars at this point:
         #   - TELEGRAM_WEBHOOK_SECRET (validated by the /webhook handler, #12)
         #   - TELEGRAM_BOT_TOKEN     (used by TelegramClient.send_message, #15)
         #   - TELEGRAM_QA_USERS      (parsed into the QA allowlist, #15)
         #   - OPENAI_API_KEY         (used by the OpenAI fallback handler, #23)
-        #   - POSTGRES_DSN           (shared Cloud SQL connection string, #31; secret may
-        #                             not yet exist in fresh deploys — set --set-secrets to
-        #                             drop the entry if absent)
+        #   - POSTGRES_DSN           (shared Cloud SQL connection string, #31)
+        #   - POSTGRES_INSTANCE      (Cloud SQL instance conn name, #31;
+        #                             also passed to --add-cloudsql-instances
+        #                             so Cloud Run mounts the Auth Proxy socket)
         # Each --set-secrets value must already have at least one Secret
         # Manager version or the deploy will fail.
         run: |
@@ -110,7 +124,8 @@ jobs:
             --region="${REGION}" \
             --image="${{ steps.image.outputs.sha_tag }}" \
             --service-account="${RUNTIME_SA}" \
-            --set-secrets="TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-default:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-default:latest,TELEGRAM_QA_USERS=telegram-qa-users:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,POSTGRES_DSN=POSTGRES_DSN:latest" \
+            --add-cloudsql-instances="${{ steps.cloudsql.outputs.connection }}" \
+            --set-secrets="TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-default:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-default:latest,TELEGRAM_QA_USERS=telegram-qa-users:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,POSTGRES_DSN=POSTGRES_DSN:latest,POSTGRES_INSTANCE=POSTGRES_INSTANCE:latest" \
             --set-env-vars="SCHEDULER_SERVICE_ACCOUNT_EMAIL=something-bot-scheduler-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
             --quiet
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -422,6 +422,62 @@ Personal usage / very small scale. Design should be clean but not absurdly over-
 
 ---
 
+## 6.8.1 Shared Postgres Persistence
+
+Some bot features require relational primitives that BigQuery is a poor fit for (small mutable state, lookups by primary key, ad-hoc joins). For these cases the bot connects to a **shared Cloud SQL Postgres instance** that lives in a separate GCP project, used by multiple internal tools.
+
+All bot tables live under a dedicated schema (default `something_bot`) so the bot never touches other tenants' tables in the shared database.
+
+### Connection Model
+
+The bot does not whitelist Cloud Run egress IPs. Instead it uses the Cloud SQL Auth Proxy:
+
+* The deploy step passes the Cloud SQL instance connection name to `gcloud run deploy --add-cloudsql-instances`, which causes Cloud Run to mount the Auth Proxy unix socket at `/cloudsql/<instance-connection-name>/` in the container filesystem.
+* The runtime service account authenticates to the Auth Proxy via IAM (`roles/cloudsql.client` on the project that owns the instance — granted out-of-band because Terraform here only manages the bot's own project).
+* The Postgres wrapper overrides psycopg's `host` connection argument with the socket path whenever the instance connection name is present in the runtime environment, so the same DSN works for local TCP development and for socket-based Cloud Run runs.
+
+No long-lived database credentials traverse the network in plaintext; psycopg connects to the local socket and the Auth Proxy handles TLS to Cloud SQL on the bot's behalf.
+
+### Required Secrets
+
+Two Secret Manager secrets in the bot's GCP project drive the wiring:
+
+* A DSN secret holding the bot's database user, password and database name. Host:port in the DSN is ignored at runtime when the socket override is active and is only used for local TCP development.
+* An instance connection name secret holding the canonical `project:region:instance` triple. Consumed both at deploy time (to mount the Auth Proxy socket) and at runtime (to point psycopg at the socket).
+
+The runtime service account is granted `roles/secretmanager.secretAccessor` on both. The deployer service account is granted access only to the instance connection name secret, so the deploy workflow can read it on the runner without also being able to read the DSN.
+
+### Database User Model
+
+The bot uses a dedicated database user inside the shared instance with the minimum privileges needed:
+
+* `USAGE` on the schemas it accesses.
+* Appropriate DML (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) on those schemas.
+* `CREATE` on the database is optional and only required if `ensure_schema()` is expected to create the bot's schema on first run; otherwise the schema is pre-created out-of-band.
+
+The bot must never assume superuser-level privileges and must not attempt cross-tenant access in the shared instance.
+
+### Wrapper Requirements
+
+A single async-friendly wrapper isolates psycopg behind a narrow interface:
+
+* `ensure_schema()` — idempotent `CREATE SCHEMA IF NOT EXISTS` for the bot's schema.
+* `execute(sql, params)` — non-returning statement.
+* `fetch_all(sql, params)` — returns a list of dicts keyed by column name.
+* `insert_row(table, row)` — schema-qualified insert; identifiers are validated against an allowlist of characters before interpolation.
+
+All driver errors funnel into a single exception type so call sites can apply the §6.9 "never bubble to Telegram" rule uniformly. The synchronous psycopg driver runs inside `asyncio.to_thread` so the FastAPI event loop stays free.
+
+### Acceptance Criteria
+
+* Cloud Run routes to Postgres via the Cloud SQL Auth Proxy socket, not over public IP.
+* DSN and instance connection name are sourced from Secret Manager and never hardcoded.
+* The runtime SA has `roles/cloudsql.client` on the owning project and `secretAccessor` on both secrets; cross-project IAM is documented as a manual step.
+* The wrapper exposes a small async API and converts driver failures into a single bot-level exception type.
+* Wrapper behavior (including the socket host override) is covered by tests using fakes/mocks — no real DB required.
+
+---
+
 ## 6.9 Branching / Routing Logic
 
 The bot must contain clear branching logic for deciding how each update should be handled.
@@ -577,7 +633,12 @@ QA_TELEGRAM_USER_IDS
 GCP_PROJECT_ID
 BIGQUERY_DATASET
 GCS_BUCKET
+OPENAI_API_KEY
+POSTGRES_DSN
+POSTGRES_INSTANCE
 ```
+
+`POSTGRES_DSN` and `POSTGRES_INSTANCE` together drive the shared Cloud SQL connection described in §6.8.1: the DSN supplies user/password/database; the instance connection name is read at deploy time (passed to `--add-cloudsql-instances`) and at runtime (used to mount the Auth Proxy socket and override the DSN host). The instance secret is also readable by the deployer SA so the deploy workflow can pass it to `gcloud`.
 
 Exact naming can be adjusted, but must be documented.
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,0 +1,63 @@
+# Shared Postgres (#31)
+
+The bot connects to a **shared Cloud SQL Postgres instance** that lives
+in a different GCP project. All bot data lives under a dedicated
+schema (default name: `something_bot`).
+
+## Connection
+
+The DSN is held in the `POSTGRES_DSN` Secret Manager secret in
+`something-bot-338300` and injected into Cloud Run via `--set-secrets`
+(see `.github/workflows/deploy.yml`).
+
+DSN form:
+
+```
+postgres://<user>:<pass>@<host>:5432/<db>?sslmode=require
+```
+
+Or, with the Cloud SQL Auth Proxy sidecar / unix socket form:
+
+```
+postgres://<user>:<pass>@/<db>?host=/cloudsql/<project>:<region>:<instance>
+```
+
+## Cross-project IAM
+
+Terraform here can't manage IAM on the other project. Out-of-band:
+
+1. On the project that owns the Cloud SQL instance, grant
+   `roles/cloudsql.client` to
+   `something-bot-cloudrun-sa@something-bot-338300.iam.gserviceaccount.com`.
+2. Create a database user inside the shared instance with `SELECT,
+   INSERT, UPDATE, DELETE, USAGE` on the `something_bot` schema only.
+3. Add the DSN to the `POSTGRES_DSN` Secret Manager secret in
+   `something-bot-338300`.
+
+## Bootstrap
+
+`PostgresStorage.ensure_schema()` issues
+`CREATE SCHEMA IF NOT EXISTS something_bot` so a freshly created DB user
+with `CREATE` on the database lands in a usable state on first call.
+
+## Wrapper API
+
+```python
+from something_really_bot.persistence.postgres import get_postgres_storage
+
+pg = get_postgres_storage()
+if pg is not None:
+    await pg.ensure_schema()
+    await pg.insert_row("reminders", {"chat_id": 42, "fire_at": dt})
+    rows = await pg.fetch_all(
+        'SELECT * FROM "something_bot"."reminders" WHERE chat_id = %s',
+        (42,),
+    )
+```
+
+All methods funnel driver failures into `PostgresError`. The underlying
+psycopg driver is synchronous; calls hop through `asyncio.to_thread` so
+they don't block the FastAPI event loop.
+
+Connections are short-lived (one per call). At our QPS that's fine; if
+this grows, swap in a pool here without touching call sites.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -6,39 +6,62 @@ schema (default name: `something_bot`).
 
 ## Connection
 
-The DSN is held in the `POSTGRES_DSN` Secret Manager secret in
-`something-bot-338300` and injected into Cloud Run via `--set-secrets`
-(see `.github/workflows/deploy.yml`).
+Two secrets in `something-bot-338300` drive the wiring:
 
-DSN form:
+- `POSTGRES_DSN` — psycopg DSN with the bot's user, password and
+  database name. The host:port in the DSN is only used for local
+  development against a TCP-reachable instance; in Cloud Run the
+  wrapper overrides it (see below).
+- `POSTGRES_INSTANCE` — Cloud SQL instance connection name in the
+  canonical `project:region:instance` form. Read at deploy time by
+  `.github/workflows/deploy.yml` and passed to
+  `gcloud run deploy --add-cloudsql-instances` so Cloud Run mounts the
+  Cloud SQL Auth Proxy socket at `/cloudsql/<conn>/`. Also injected
+  into the runtime environment via `--set-secrets` so the wrapper can
+  point psycopg at the socket.
+
+DSN form (any of these work — the host portion is ignored at runtime
+when `POSTGRES_INSTANCE` is set):
 
 ```
-postgres://<user>:<pass>@<host>:5432/<db>?sslmode=require
+postgres://<user>:<pass>@<host>:5432/<db>
+postgres://<user>:<pass>@/<db>
 ```
 
-Or, with the Cloud SQL Auth Proxy sidecar / unix socket form:
+How the wrapper routes to the socket: psycopg `connect()` accepts a
+`host=` kwarg that overrides whatever host is in the DSN string.
+`PostgresStorage._default_factory` passes
+`host=/cloudsql/<POSTGRES_INSTANCE>` whenever the instance is set, so
+the same DSN string works for local TCP development and for Cloud Run
+without any conditional DSN rewriting.
 
-```
-postgres://<user>:<pass>@/<db>?host=/cloudsql/<project>:<region>:<instance>
-```
+Locally (no `POSTGRES_INSTANCE`), psycopg uses the DSN host:port as-is.
 
 ## Cross-project IAM
 
-Terraform here can't manage IAM on the other project. Out-of-band:
+Terraform here can't manage IAM on the project that owns the Cloud SQL
+instance. Out-of-band, on that project:
 
-1. On the project that owns the Cloud SQL instance, grant
-   `roles/cloudsql.client` to
-   `something-bot-cloudrun-sa@something-bot-338300.iam.gserviceaccount.com`.
-2. Create a database user inside the shared instance with `SELECT,
-   INSERT, UPDATE, DELETE, USAGE` on the `something_bot` schema only.
-3. Add the DSN to the `POSTGRES_DSN` Secret Manager secret in
-   `something-bot-338300`.
+1. Grant `roles/cloudsql.client` to
+   `something-bot-cloudrun-sa@something-bot-338300.iam.gserviceaccount.com`
+   so the runtime SA can open Auth Proxy connections.
+2. Create a database inside the shared instance for the bot.
+3. Create a database user for the bot with `USAGE` on the schemas it
+   needs and the appropriate DML grants. `CREATE` on the database is
+   only required if you want `ensure_schema()` to create the
+   `something_bot` schema on first run; otherwise pre-create the
+   schema and grant DML on it.
+4. Put the DSN into `POSTGRES_DSN` and the instance connection name
+   into `POSTGRES_INSTANCE` in `something-bot-338300`'s Secret
+   Manager.
 
 ## Bootstrap
 
 `PostgresStorage.ensure_schema()` issues
-`CREATE SCHEMA IF NOT EXISTS something_bot` so a freshly created DB user
-with `CREATE` on the database lands in a usable state on first call.
+`CREATE SCHEMA IF NOT EXISTS something_bot`. Call sites that need a
+schema before writing should invoke it once on startup. If the bot's
+DB user lacks `CREATE` on the database, the call will fail — in that
+case create the schema out-of-band and skip `ensure_schema()`.
 
 ## Wrapper API
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -163,6 +163,11 @@ data "google_secret_manager_secret" "postgres_dsn" {
   secret_id = var.postgres_dsn_secret_name
 }
 
+data "google_secret_manager_secret" "postgres_instance" {
+  project   = var.project_id
+  secret_id = var.postgres_instance_secret_name
+}
+
 # --------------------------------------------------------------------------- #
 # Secret Manager — webhook secret placeholder per bot (value injected out-of-band)
 # --------------------------------------------------------------------------- #
@@ -225,6 +230,13 @@ resource "google_secret_manager_secret_iam_member" "cloudrun_postgres_dsn" {
   member    = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "cloudrun_postgres_instance" {
+  project   = var.project_id
+  secret_id = data.google_secret_manager_secret.postgres_instance.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
 # --------------------------------------------------------------------------- #
 # Secret access for the deployer service account
 #
@@ -248,6 +260,17 @@ resource "google_secret_manager_secret_iam_member" "deployer_webhook_secret" {
 
   project   = var.project_id
   secret_id = google_secret_manager_secret.telegram_webhook_secret[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+# The deploy workflow reads POSTGRES_INSTANCE on the runner so it can pass
+# the Cloud SQL connection name to `gcloud run deploy --add-cloudsql-instances`.
+# Bind the deployer SA explicitly rather than the runtime SA's binding above
+# so the two identities stay independently revocable.
+resource "google_secret_manager_secret_iam_member" "deployer_postgres_instance" {
+  project   = var.project_id
+  secret_id = data.google_secret_manager_secret.postgres_instance.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.deployer.email}"
 }
@@ -327,6 +350,7 @@ resource "google_cloud_run_v2_service" "main" {
     google_secret_manager_secret_iam_member.cloudrun_webhook_secret,
     google_secret_manager_secret_iam_member.cloudrun_openai,
     google_secret_manager_secret_iam_member.cloudrun_postgres_dsn,
+    google_secret_manager_secret_iam_member.cloudrun_postgres_instance,
     google_storage_bucket_iam_member.cloudrun_files,
   ]
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -158,6 +158,11 @@ data "google_secret_manager_secret" "openai_api_key" {
   secret_id = var.openai_api_key_secret_name
 }
 
+data "google_secret_manager_secret" "postgres_dsn" {
+  project   = var.project_id
+  secret_id = var.postgres_dsn_secret_name
+}
+
 # --------------------------------------------------------------------------- #
 # Secret Manager — webhook secret placeholder per bot (value injected out-of-band)
 # --------------------------------------------------------------------------- #
@@ -209,6 +214,13 @@ resource "google_secret_manager_secret_iam_member" "cloudrun_webhook_secret" {
 resource "google_secret_manager_secret_iam_member" "cloudrun_openai" {
   project   = var.project_id
   secret_id = data.google_secret_manager_secret.openai_api_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudrun_postgres_dsn" {
+  project   = var.project_id
+  secret_id = data.google_secret_manager_secret.postgres_dsn.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cloudrun.email}"
 }
@@ -314,6 +326,7 @@ resource "google_cloud_run_v2_service" "main" {
     google_secret_manager_secret_iam_member.cloudrun_qa_users,
     google_secret_manager_secret_iam_member.cloudrun_webhook_secret,
     google_secret_manager_secret_iam_member.cloudrun_openai,
+    google_secret_manager_secret_iam_member.cloudrun_postgres_dsn,
     google_storage_bucket_iam_member.cloudrun_files,
   ]
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -95,3 +95,9 @@ variable "postgres_dsn_secret_name" {
   type        = string
   default     = "POSTGRES_DSN"
 }
+
+variable "postgres_instance_secret_name" {
+  description = "Existing Secret Manager secret holding the Cloud SQL instance connection name (`project:region:instance`) for the shared Postgres instance (#31). Consumed by --add-cloudsql-instances on the Cloud Run deploy step and by PostgresStorage to route through the Auth Proxy socket."
+  type        = string
+  default     = "POSTGRES_INSTANCE"
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -89,3 +89,9 @@ variable "openai_api_key_secret_name" {
   type        = string
   default     = "OPENAI_API_KEY"
 }
+
+variable "postgres_dsn_secret_name" {
+  description = "Existing Secret Manager secret holding the DSN of the shared Cloud SQL Postgres instance (#31). The instance lives in a different GCP project; cross-project roles/cloudsql.client on the Cloud Run runtime SA is granted on the owning project, not here."
+  type        = string
+  default     = "POSTGRES_DSN"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "google-cloud-storage>=3.10,<4",
     "httpx>=0.28,<0.29",
     "openai>=2.37,<3",
+    "psycopg[binary]>=3.2,<4",
     "pydantic-settings>=2.14,<3",
     "uvicorn[standard]>=0.47,<0.48",
 ]

--- a/src/something_really_bot/config.py
+++ b/src/something_really_bot/config.py
@@ -106,6 +106,26 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Shared Postgres (#31) ---
+    postgres_dsn: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Connection string for the shared Cloud SQL Postgres instance hosting "
+            "the something-bot schema (#31). When unset, the Postgres wrapper "
+            "is not built and any call site that depends on it gracefully "
+            "no-ops. Format: postgres://<user>:<pass>@<host>:5432/<db>?sslmode=require "
+            "(or the Cloud SQL Auth Proxy unix socket form: "
+            "postgres://<user>:<pass>@/<db>?host=/cloudsql/<project>:<region>:<instance>)."
+        ),
+    )
+    postgres_schema: str = Field(
+        default="something_bot",
+        description=(
+            "Postgres schema the bot writes to inside the shared DB (#31). Created "
+            "on first connection if missing (CREATE SCHEMA IF NOT EXISTS)."
+        ),
+    )
+
     @field_validator("telegram_qa_user_ids", mode="before")
     @classmethod
     def _parse_qa_users(cls, raw: Any) -> Any:

--- a/src/something_really_bot/config.py
+++ b/src/something_really_bot/config.py
@@ -125,6 +125,17 @@ class Settings(BaseSettings):
             "on first connection if missing (CREATE SCHEMA IF NOT EXISTS)."
         ),
     )
+    postgres_instance: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Cloud SQL instance connection name (project:region:instance) for the "
+            "shared Postgres instance. When set, the Postgres wrapper routes psycopg "
+            "through the Cloud SQL Auth Proxy socket at /cloudsql/<value>/ by "
+            "overriding the host kwarg, regardless of what host:port the DSN "
+            "specifies. Unset locally so psycopg uses the DSN's host:port verbatim. "
+            "Treated as a secret so the value never lands in logs."
+        ),
+    )
 
     @field_validator("telegram_qa_user_ids", mode="before")
     @classmethod

--- a/src/something_really_bot/persistence/postgres.py
+++ b/src/something_really_bot/persistence/postgres.py
@@ -86,9 +86,7 @@ class PostgresStorage:
     async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
         await self._run(lambda conn: self._exec(conn, sql, params))
 
-    async def fetch_all(
-        self, sql: str, params: tuple[Any, ...] = ()
-    ) -> list[dict[str, Any]]:
+    async def fetch_all(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
         return await self._run(lambda conn: self._fetch(conn, sql, params))
 
     async def insert_row(self, table: str, row: Mapping[str, Any]) -> None:
@@ -106,10 +104,7 @@ class PostgresStorage:
 
         columns = ", ".join(f'"{c}"' for c in row)
         placeholders = ", ".join(["%s"] * len(row))
-        sql = (
-            f'INSERT INTO "{self._schema}"."{table}" ({columns}) '
-            f"VALUES ({placeholders})"
-        )
+        sql = f'INSERT INTO "{self._schema}"."{table}" ({columns}) VALUES ({placeholders})'
         await self.execute(sql, tuple(row.values()))
 
     # --------------------------------------------------------------- #

--- a/src/something_really_bot/persistence/postgres.py
+++ b/src/something_really_bot/persistence/postgres.py
@@ -1,0 +1,157 @@
+"""Tiny wrapper around the shared Cloud SQL Postgres instance (#31).
+
+The DB lives in a different GCP project; the bot connects with a DSN
+held in the ``POSTGRES_DSN`` Secret Manager secret. Cross-project IAM
+(``roles/cloudsql.client`` for the Cloud Run runtime SA) is granted
+out-of-band on the owning project — Terraform here can't manage it.
+
+The wrapper is deliberately small:
+
+- ``PostgresStorage.ensure_schema()`` issues ``CREATE SCHEMA IF NOT EXISTS``.
+- ``PostgresStorage.execute(sql, params)`` runs a non-returning statement.
+- ``PostgresStorage.fetch_all(sql, params)`` returns ``list[dict[str, Any]]``.
+- ``PostgresStorage.insert_row(table, row)`` inserts a dict, schema-qualified.
+
+The synchronous ``psycopg`` driver runs inside ``asyncio.to_thread`` so
+the FastAPI event loop stays free, matching the pattern used by the GCS
+and GA4 wrappers.
+
+Errors are funneled into :class:`PostgresError`; callers decide whether
+to surface or swallow per the SPEC §6.9 "never bubble to Telegram" rule.
+"""
+
+import asyncio
+from collections.abc import Callable, Mapping
+from functools import lru_cache
+from typing import Any
+
+from pydantic import SecretStr
+
+from something_really_bot.config import get_settings
+from something_really_bot.logging import get_logger
+
+_logger = get_logger(__name__)
+
+ConnectionFactory = Callable[[], Any]
+
+
+class PostgresError(Exception):
+    """Raised on any Postgres driver/connection failure."""
+
+
+class PostgresStorage:
+    """Sync-Postgres helper wrapped for the asyncio event loop."""
+
+    def __init__(
+        self,
+        dsn: SecretStr,
+        *,
+        schema: str = "something_bot",
+        connection_factory: ConnectionFactory | None = None,
+    ) -> None:
+        self._dsn = dsn
+        self._schema = schema
+        self._factory = connection_factory or self._default_factory
+
+    @property
+    def schema(self) -> str:
+        return self._schema
+
+    async def ensure_schema(self) -> None:
+        """``CREATE SCHEMA IF NOT EXISTS <schema>`` — idempotent."""
+        await self._run(
+            lambda conn: self._exec(
+                conn,
+                f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"',
+                params=(),
+            )
+        )
+
+    async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        await self._run(lambda conn: self._exec(conn, sql, params))
+
+    async def fetch_all(
+        self, sql: str, params: tuple[Any, ...] = ()
+    ) -> list[dict[str, Any]]:
+        return await self._run(lambda conn: self._fetch(conn, sql, params))
+
+    async def insert_row(self, table: str, row: Mapping[str, Any]) -> None:
+        """Insert ``row`` into ``<schema>.<table>``.
+
+        Column names are quoted with double-quotes to preserve casing;
+        values pass through psycopg parameter substitution so SQL
+        injection from values isn't possible. ``table`` is rejected if
+        it contains anything but ASCII letters / digits / underscores.
+        """
+        if not _is_safe_identifier(table):
+            raise PostgresError(f"Unsafe table identifier: {table!r}")
+        if not row:
+            raise PostgresError("insert_row: row must not be empty")
+
+        columns = ", ".join(f'"{c}"' for c in row)
+        placeholders = ", ".join(["%s"] * len(row))
+        sql = (
+            f'INSERT INTO "{self._schema}"."{table}" ({columns}) '
+            f"VALUES ({placeholders})"
+        )
+        await self.execute(sql, tuple(row.values()))
+
+    # --------------------------------------------------------------- #
+    # Internals
+    # --------------------------------------------------------------- #
+
+    async def _run(self, work: Callable[[Any], Any]) -> Any:
+        try:
+            return await asyncio.to_thread(self._run_sync, work)
+        except PostgresError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — funnel all driver errors
+            _logger.warning(
+                "postgres_call_failed",
+                extra={"exception_type": type(exc).__name__},
+            )
+            raise PostgresError(str(exc)) from exc
+
+    def _run_sync(self, work: Callable[[Any], Any]) -> Any:
+        conn = self._factory()
+        try:
+            try:
+                result = work(conn)
+                conn.commit()
+                return result
+            except Exception:
+                conn.rollback()
+                raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _exec(conn: Any, sql: str, params: tuple[Any, ...]) -> None:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+
+    @staticmethod
+    def _fetch(conn: Any, sql: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            columns = [d.name for d in (cur.description or [])]
+            return [dict(zip(columns, row, strict=False)) for row in cur.fetchall()]
+
+    def _default_factory(self) -> Any:
+        # Deferred so test doubles don't need psycopg installed.
+        import psycopg
+
+        return psycopg.connect(self._dsn.get_secret_value(), autocommit=False)
+
+
+def _is_safe_identifier(name: str) -> bool:
+    return bool(name) and all(c.isalnum() or c == "_" for c in name)
+
+
+@lru_cache(maxsize=1)
+def get_postgres_storage() -> PostgresStorage | None:
+    """Return the process-wide :class:`PostgresStorage`, or ``None`` if no DSN."""
+    settings = get_settings()
+    if settings.postgres_dsn is None:
+        return None
+    return PostgresStorage(dsn=settings.postgres_dsn, schema=settings.postgres_schema)

--- a/src/something_really_bot/persistence/postgres.py
+++ b/src/something_really_bot/persistence/postgres.py
@@ -1,9 +1,23 @@
 """Tiny wrapper around the shared Cloud SQL Postgres instance (#31).
 
-The DB lives in a different GCP project; the bot connects with a DSN
-held in the ``POSTGRES_DSN`` Secret Manager secret. Cross-project IAM
-(``roles/cloudsql.client`` for the Cloud Run runtime SA) is granted
-out-of-band on the owning project — Terraform here can't manage it.
+The DB lives in a different GCP project. The bot connects via the Cloud
+SQL Auth Proxy: Cloud Run mounts the proxy socket at
+``/cloudsql/<instance-connection-name>/`` (configured by
+``gcloud run deploy --add-cloudsql-instances=<conn>``) and authenticates
+with the runtime SA's IAM, which holds ``roles/cloudsql.client`` on the
+owning project.
+
+Two secrets drive the wiring:
+
+- ``POSTGRES_DSN``     — psycopg connection string with the bot's
+  user/password/database. The host:port in the DSN is intentionally
+  **ignored at runtime**; it's there so the same DSN works for local
+  TCP connections during development.
+- ``POSTGRES_INSTANCE`` — Cloud SQL instance connection name
+  (``project:region:instance``). When present, the wrapper overrides
+  the DSN's host with ``/cloudsql/<POSTGRES_INSTANCE>`` so psycopg
+  routes through the Auth Proxy socket regardless of what the DSN says.
+  Unset locally → psycopg uses the DSN's host:port as-is.
 
 The wrapper is deliberately small:
 
@@ -47,10 +61,12 @@ class PostgresStorage:
         dsn: SecretStr,
         *,
         schema: str = "something_bot",
+        instance_connection_name: str | None = None,
         connection_factory: ConnectionFactory | None = None,
     ) -> None:
         self._dsn = dsn
         self._schema = schema
+        self._instance = instance_connection_name
         self._factory = connection_factory or self._default_factory
 
     @property
@@ -141,7 +157,13 @@ class PostgresStorage:
         # Deferred so test doubles don't need psycopg installed.
         import psycopg
 
-        return psycopg.connect(self._dsn.get_secret_value(), autocommit=False)
+        kwargs: dict[str, Any] = {"autocommit": False}
+        if self._instance:
+            # Route through the Cloud SQL Auth Proxy socket; psycopg
+            # kwargs override the host:port in the DSN string, so the
+            # same DSN works locally (TCP) and in Cloud Run (socket).
+            kwargs["host"] = f"/cloudsql/{self._instance}"
+        return psycopg.connect(self._dsn.get_secret_value(), **kwargs)
 
 
 def _is_safe_identifier(name: str) -> bool:
@@ -154,4 +176,13 @@ def get_postgres_storage() -> PostgresStorage | None:
     settings = get_settings()
     if settings.postgres_dsn is None:
         return None
-    return PostgresStorage(dsn=settings.postgres_dsn, schema=settings.postgres_schema)
+    instance = (
+        settings.postgres_instance.get_secret_value()
+        if settings.postgres_instance is not None
+        else None
+    )
+    return PostgresStorage(
+        dsn=settings.postgres_dsn,
+        schema=settings.postgres_schema,
+        instance_connection_name=instance,
+    )

--- a/tests/unit/persistence/test_postgres.py
+++ b/tests/unit/persistence/test_postgres.py
@@ -143,3 +143,52 @@ async def test_driver_exception_funnels_to_postgres_error_and_rolls_back() -> No
     assert "connection lost" in str(excinfo.value)
     assert conn.rolled_back is True
     assert conn.closed is True
+
+
+def test_default_factory_passes_socket_host_when_instance_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an instance connection name is configured, the wrapper must
+    override psycopg's `host` so the connection lands on the Cloud SQL
+    Auth Proxy socket instead of the DSN's host:port."""
+    calls: list[tuple[tuple, dict]] = []
+    fake_psycopg = type(
+        "FakePsycopg",
+        (),
+        {"connect": staticmethod(lambda *a, **kw: calls.append((a, kw)) or object())},
+    )
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", fake_psycopg)
+
+    storage = PostgresStorage(
+        dsn=SecretStr("postgres://u:p@ignored:5432/db"),
+        instance_connection_name="proj:region:inst",
+    )
+    storage._default_factory()
+
+    assert calls == [
+        (
+            ("postgres://u:p@ignored:5432/db",),
+            {"autocommit": False, "host": "/cloudsql/proj:region:inst"},
+        )
+    ]
+
+
+def test_default_factory_omits_host_kwarg_when_no_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local development path: no instance set → psycopg uses the DSN
+    host:port verbatim, no host override."""
+    calls: list[tuple[tuple, dict]] = []
+    fake_psycopg = type(
+        "FakePsycopg",
+        (),
+        {"connect": staticmethod(lambda *a, **kw: calls.append((a, kw)) or object())},
+    )
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", fake_psycopg)
+
+    storage = PostgresStorage(dsn=SecretStr("postgres://u:p@localhost:5432/db"))
+    storage._default_factory()
+
+    assert calls == [
+        (("postgres://u:p@localhost:5432/db",), {"autocommit": False})
+    ]

--- a/tests/unit/persistence/test_postgres.py
+++ b/tests/unit/persistence/test_postgres.py
@@ -78,9 +78,7 @@ async def test_ensure_schema_runs_create_schema_if_not_exists() -> None:
 
     await storage.ensure_schema()
 
-    assert conn.cursor_obj.executed == [
-        ('CREATE SCHEMA IF NOT EXISTS "something_bot"', ())
-    ]
+    assert conn.cursor_obj.executed == [('CREATE SCHEMA IF NOT EXISTS "something_bot"', ())]
     assert conn.committed is True
     assert conn.closed is True
 
@@ -132,9 +130,7 @@ async def test_fetch_all_returns_rows_as_dicts() -> None:
 
 
 async def test_driver_exception_funnels_to_postgres_error_and_rolls_back() -> None:
-    conn = _FakeConnection(
-        cursor_obj=_FakeCursor(raise_on_execute=RuntimeError("connection lost"))
-    )
+    conn = _FakeConnection(cursor_obj=_FakeCursor(raise_on_execute=RuntimeError("connection lost")))
     storage = _storage_with(conn)
 
     with pytest.raises(PostgresError) as excinfo:
@@ -189,6 +185,4 @@ def test_default_factory_omits_host_kwarg_when_no_instance(
     storage = PostgresStorage(dsn=SecretStr("postgres://u:p@localhost:5432/db"))
     storage._default_factory()
 
-    assert calls == [
-        (("postgres://u:p@localhost:5432/db",), {"autocommit": False})
-    ]
+    assert calls == [(("postgres://u:p@localhost:5432/db",), {"autocommit": False})]

--- a/tests/unit/persistence/test_postgres.py
+++ b/tests/unit/persistence/test_postgres.py
@@ -1,0 +1,145 @@
+"""Tests for :mod:`something_really_bot.persistence.postgres` (#31).
+
+Uses a hand-rolled fake connection rather than the real psycopg
+driver: we want to verify the wrapper's commit/rollback/quoting
+behaviour without needing a Postgres server in CI.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from something_really_bot.persistence.postgres import (
+    PostgresError,
+    PostgresStorage,
+)
+
+
+@dataclass
+class _FakeColumn:
+    name: str
+
+
+@dataclass
+class _FakeCursor:
+    rows: list[tuple] = field(default_factory=list)
+    description: list[_FakeColumn] | None = None
+    executed: list[tuple[str, tuple]] = field(default_factory=list)
+    raise_on_execute: BaseException | None = None
+    fetch_payload: list[tuple] = field(default_factory=list)
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        if self.raise_on_execute is not None:
+            raise self.raise_on_execute
+        self.executed.append((sql, params))
+
+    def fetchall(self) -> list[tuple]:
+        return list(self.fetch_payload)
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_a: Any) -> None: ...
+
+
+@dataclass
+class _FakeConnection:
+    cursor_obj: _FakeCursor = field(default_factory=_FakeCursor)
+    committed: bool = False
+    rolled_back: bool = False
+    closed: bool = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _storage_with(conn: _FakeConnection, *, schema: str = "something_bot") -> PostgresStorage:
+    return PostgresStorage(
+        dsn=SecretStr("postgres://stub"),
+        schema=schema,
+        connection_factory=lambda: conn,
+    )
+
+
+async def test_ensure_schema_runs_create_schema_if_not_exists() -> None:
+    conn = _FakeConnection()
+    storage = _storage_with(conn)
+
+    await storage.ensure_schema()
+
+    assert conn.cursor_obj.executed == [
+        ('CREATE SCHEMA IF NOT EXISTS "something_bot"', ())
+    ]
+    assert conn.committed is True
+    assert conn.closed is True
+
+
+async def test_insert_row_uses_schema_and_table_quoting() -> None:
+    conn = _FakeConnection()
+    storage = _storage_with(conn)
+
+    await storage.insert_row("messages", {"id": 1, "body": "hi"})
+
+    sql, params = conn.cursor_obj.executed[0]
+    assert sql == 'INSERT INTO "something_bot"."messages" ("id", "body") VALUES (%s, %s)'
+    assert params == (1, "hi")
+
+
+async def test_insert_row_rejects_unsafe_table_identifier() -> None:
+    conn = _FakeConnection()
+    storage = _storage_with(conn)
+
+    with pytest.raises(PostgresError) as excinfo:
+        await storage.insert_row("messages; DROP TABLE x;", {"id": 1})
+
+    assert "Unsafe table identifier" in str(excinfo.value)
+    assert conn.cursor_obj.executed == []
+    assert conn.closed is False  # never connected
+
+
+async def test_insert_row_rejects_empty_row() -> None:
+    conn = _FakeConnection()
+    storage = _storage_with(conn)
+
+    with pytest.raises(PostgresError):
+        await storage.insert_row("messages", {})
+
+
+async def test_fetch_all_returns_rows_as_dicts() -> None:
+    conn = _FakeConnection(
+        cursor_obj=_FakeCursor(
+            description=[_FakeColumn("id"), _FakeColumn("body")],
+            fetch_payload=[(1, "a"), (2, "b")],
+        )
+    )
+    storage = _storage_with(conn)
+
+    rows = await storage.fetch_all("SELECT id, body FROM x", ())
+
+    assert rows == [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
+    assert conn.committed is True
+
+
+async def test_driver_exception_funnels_to_postgres_error_and_rolls_back() -> None:
+    conn = _FakeConnection(
+        cursor_obj=_FakeCursor(raise_on_execute=RuntimeError("connection lost"))
+    )
+    storage = _storage_with(conn)
+
+    with pytest.raises(PostgresError) as excinfo:
+        await storage.execute("SELECT 1", ())
+
+    assert "connection lost" in str(excinfo.value)
+    assert conn.rolled_back is True
+    assert conn.closed is True

--- a/uv.lock
+++ b/uv.lock
@@ -491,6 +491,42 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -725,6 +761,7 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "openai" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -744,6 +781,7 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=3.10,<4" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "openai", specifier = ">=2.37,<3" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic-settings", specifier = ">=2.14,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47,<0.48" },
 ]
@@ -799,6 +837,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a small async-friendly Postgres wrapper (`PostgresStorage`) backed by `psycopg`, plus the infra and deploy wiring needed to reach the **shared Cloud SQL instance in another GCP project** through the Cloud SQL Auth Proxy — no public-IP whitelisting required.

Closes #31.

### Connection model

- The deploy workflow reads `POSTGRES_INSTANCE` from Secret Manager and passes it to `gcloud run deploy --add-cloudsql-instances`. Cloud Run mounts the Auth Proxy socket at `/cloudsql/<conn>/`.
- The runtime container also gets `POSTGRES_INSTANCE` and `POSTGRES_DSN` injected via `--set-secrets`.
- `PostgresStorage._default_factory` overrides psycopg's `host` kwarg with the socket path whenever the instance is set, so the same DSN works for local TCP development and Cloud Run socket runs.

### What's in this PR

- `src/something_really_bot/persistence/postgres.py` — the wrapper (`ensure_schema`, `execute`, `fetch_all`, `insert_row`), with all driver errors funneled into `PostgresError`. Sync psycopg runs through `asyncio.to_thread`.
- `src/something_really_bot/config.py` — `postgres_dsn`, `postgres_instance`, `postgres_schema` settings.
- `infra/terraform/main.tf` + `variables.tf` — `POSTGRES_DSN` / `POSTGRES_INSTANCE` data sources, Cloud Run runtime SA grants, deployer SA grant for the instance secret only (so the workflow can read it on the runner without also getting the DSN).
- `.github/workflows/deploy.yml` — resolves the instance connection name on the runner, masks it, then passes it to `--add-cloudsql-instances` and `--set-secrets`.
- `docs/postgres.md` + `SPEC.md` §6.8.1 — documents the connection model, secrets, cross-project IAM, and the host-override mechanic. No sensitive values.
- Unit tests cover `ensure_schema`, schema-qualified insert, identifier validation, rollback on driver failure, and the host-override behavior of `_default_factory` (with and without an instance set).

### Out-of-band prerequisites (manual)

On the project that owns the shared Cloud SQL instance:

1. Grant `roles/cloudsql.client` to `something-bot-cloudrun-sa@something-bot-338300.iam.gserviceaccount.com`.
2. Create the bot's DB, DB user, and required schema grants.
3. Add `POSTGRES_DSN` (DSN string) and `POSTGRES_INSTANCE` (`project:region:instance`) to Secret Manager in `something-bot-338300`.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (141 passed)
- [x] `terraform fmt -check` clean
- [ ] After merge: confirm the next deploy run shows the new `--add-cloudsql-instances` flag and the service boots without DB errors.
- [ ] Smoke-test from Cloud Run that a call site can `ensure_schema()` and `insert_row()` against the shared instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)