### PR TITLE
Grant CI/Deploy permissions the reusable workflow declares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 jobs:
   checks:
     uses: ./.github/workflows/_checks.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 env:
   PROJECT_ID: something-bot-338300
@@ -22,6 +24,7 @@ env:
 jobs:
   checks:
     uses: ./.github/workflows/_checks.yml
+    secrets: inherit
 
   preflight:
     name: Deploy preflight (secrets configured?)


### PR DESCRIPTION
## Summary

- #39 added a `terraform-plan` job to `_checks.yml` declaring `id-token: write` and `pull-requests: write` permissions; reusable-workflow jobs cannot claim permissions the caller has not granted, so GitHub rejected the workflow with `startup_failure` on every push to master and every PR after #39 landed.
- Grant the elevated scopes on both callers (`ci.yml`, `deploy.yml`) and pass `secrets: inherit` so the preflight gate can read `GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_PLANNER_SERVICE_ACCOUNT`.

## Test plan

- [x] Push branch, watch this PR's CI run actually start (proves workflow validates)
- [ ] Re-run Deploy on master after merge — confirm it boots past the validation stage