### PR TITLE
Make terraform-plan read-only and PR-only

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -97,7 +97,7 @@ jobs:
     name: Terraform — plan
     runs-on: ubuntu-latest
     needs: [terraform-checks, terraform-plan-preflight]
-    if: needs.terraform-plan-preflight.outputs.enabled == 'true'
+    if: needs.terraform-plan-preflight.outputs.enabled == 'true' && github.event_name == 'pull_request'
     permissions:
       contents: read
       id-token: write
@@ -134,6 +134,7 @@ jobs:
           terraform plan \
             -no-color \
             -input=false \
+            -lock=false \
             -var-file=environments/prod.tfvars \
             -out=tfplan \
             -detailed-exitcode \


### PR DESCRIPTION
## Summary

- #39's `terraform-plan` job ran on master pushes too, dragging the Deploy workflow's `checks → preflight → deploy` chain down with it.
- It also tried to acquire a state lock, but the planner SA is granted only `roles/viewer + roles/iam.securityReviewer + roles/secretmanager.viewer` — so `storage.objects.create` on the state bucket was denied and plan exited 1.
- Pass `-lock=false` (plan is read-only by design — giving the planner SA bucket write would defeat that) and gate the job to `pull_request` events (the comment-on-PR step is its only output).

## Test plan

- [x] This PR's `terraform — plan` job actually runs (event is `pull_request`) and passes with `-lock=false`
- [ ] After merge, next master push's Deploy run boots past the checks gate (terraform-plan is skipped on push events)